### PR TITLE
Add first cut at verifiable accreditation section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,6 +142,8 @@
         enable a list operator to share a list of Verifiable Issuers and Verifiers in a way that
         is useful to a particular transaction.
       </p>
+
+        <p class="issue" data-number="31"></p>
     </section>
 
     <section id="sotd">
@@ -1350,7 +1352,7 @@ issue, and the hierarchy of authority, authorization, and delegation.
   ],
   "type": [
     "VerifiableCredential",
-    "VerifiableAccreditationCredential"
+    "AccreditationCredential"
   ],
   "issuer": "did:web:accreditor.example",
   "validFrom": "2025-01-01T00:00:00Z",
@@ -1388,6 +1390,8 @@ issue, and the hierarchy of authority, authorization, and delegation.
   }
 }
         </pre>
+
+        <p class="issue" data-number="32"></p>
       </section>
     </section>
 


### PR DESCRIPTION
This PR attempts to suggest a non-centralized mechanism for a root authority to grant an issuer the right to issue specific types of credentials.

The section can be previewed here: https://pr-preview.s3.amazonaws.com/w3c-ccg/verifiable-issuers-verifiers/pull/29.html#decentralized-verifiable-roles


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/verifiable-issuers-verifiers/pull/29.html" title="Last updated on Aug 23, 2025, 9:39 PM UTC (26a166f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/verifiable-issuers-verifiers/29/82ce385...26a166f.html" title="Last updated on Aug 23, 2025, 9:39 PM UTC (26a166f)">Diff</a>