### PR TITLE
Add EU ETSI Trust Services support to data model

### DIFF
--- a/index.html
+++ b/index.html
@@ -1253,23 +1253,20 @@ publishes an European Union ETSI Trust Services list [[ETSI-TRUST-LISTS]].
     "VerifiableCredential",
     "VerifiableRecognitionCredential"
   ],
-  "issuer": {
-    "id": "did:web:ec.europa.example",
-    "type": "RecognizedIssuer",
-    "name": "Utopian Commission"
-  },
+  "issuer": "did:web:ec.europa.example",
   "validFrom": "2025-01-01T00:00:00Z",
   "validUntil": "2030-01-01T00:00:00Z",
   "credentialSubject": [{
-    "id": "did:web:uto.state.example",
+    "id": "did:web:ec.europa.example",
     "type": "RecognizedEntity",
-    "name": "State of Utopia",
-    "legalName": "State of Utopia",
-    "image": "https://uto.state.example/logo.png",
-    "url": "https://uto.state.example/",
+    "name": "Utopian Commission",
+    "legalName": "The Utopian Commission",
+    "image": "https://ec.europa.example/logo.png",
+    "url": "https://ec.europa.example/",
     "recognizedIn": {
-      "id": "https://utopia.example/tsl/UT_TSL.xml",
-      "type": "EtsiTrustServiceList"
+      "id": "https://ec.europa.example/tsl/lotl.xml",
+      "type": "EtsiTrustServiceList",
+      "name": "Utopian Commission List of the Lists"
     }
   }],
   "proof": {


### PR DESCRIPTION
This PR adds the EU ETSI Trust Services support to the data model.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/verifiable-issuers-verifiers/pull/42.html" title="Last updated on Feb 25, 2026, 1:21 AM UTC (633b607)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/verifiable-issuers-verifiers/42/2cdd528...633b607.html" title="Last updated on Feb 25, 2026, 1:21 AM UTC (633b607)">Diff</a>