### PR TITLE
Add section on validating before sharing.

### DIFF
--- a/index.html
+++ b/index.html
@@ -803,7 +803,7 @@ before acting upon it or sharing it further. This includes confirming that the
 reason to trust for the given recognition domain, and that the credential has
 not expired or been revoked. Implementers cannot rely solely on the fact
 that a peer has already accepted a credential as evidence of its validity.
-Instead, a [=verifier=]] needs to vet the issuer of the recognition credential
+Instead, a [=verifier=] needs to vet the issuer of the recognition credential
 as well as the recognized action independently of receiving the
 `VerifiableRecognitionCredential` and can only depend on information from the
 credential once trust has been established on the issuing entity.


### PR DESCRIPTION
This PR attempts to address issue #3 by adding a section on validating the issuer and action of a VRC before using it to make decisions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/verifiable-issuers-verifiers/pull/55.html" title="Last updated on Mar 17, 2026, 9:27 PM UTC (28b6d90)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/verifiable-issuers-verifiers/55/c5fbc2a...28b6d90.html" title="Last updated on Mar 17, 2026, 9:27 PM UTC (28b6d90)">Diff</a>