### PR TITLE
Add CG Report; configure respec to match future.

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <script type="text/javascript" class="remove">
       var respecConfig = {
         // specification status (e.g., WD, LCWD, NOTE, etc.). If in doubt use ED.
-        specStatus: "CG-DRAFT",
+        specStatus: "CG-FINAL",
 
         // the specification's short name, as in http://www.w3.org/TR/short-name/
         shortName: "vc-recognition",
@@ -31,6 +31,7 @@
 
         // if there a publicly available Editor's Draft, this is the link
         edDraftURI: "https://github.com/w3c-ccg/vc-recognition/",
+        latestVersion: "https://www.w3.org/community/reports/credentials/CG-FINAL-vc-recognition-YYYYMMDD/",
 
         // if this is a LCWD, uncomment and set the end of its review period
         // lcEnd: "2009-08-05",

--- a/transitions/2026/CG-FINAL/index.html
+++ b/transitions/2026/CG-FINAL/index.html
@@ -1,0 +1,1503 @@
+<!DOCTYPE html><html lang="en" dir="ltr"><head>
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+<meta name="generator" content="ReSpec 35.8.0">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<style>
+span.example-title{text-transform:none}
+:is(aside,div).example,div.illegal-example{padding:.5em;margin:1em 0;position:relative;clear:both}
+div.illegal-example{color:red}
+div.illegal-example p{color:#000}
+aside.example div.example{border-left-width:.1em;border-color:#999;background:#fff}
+</style>
+<style>
+dfn{cursor:pointer}
+.dfn-panel{position:absolute;z-index:35;min-width:300px;max-width:500px;padding:.5em .75em;margin-top:.6em;font-family:"Helvetica Neue",sans-serif;font-size:small;background:#fff;background:var(--indextable-hover-bg,#fff);color:#000;color:var(--text,#000);box-shadow:0 1em 3em -.4em rgba(0,0,0,.3),0 0 1px 1px rgba(0,0,0,.05);box-shadow:0 1em 3em -.4em var(--tocsidebar-shadow,rgba(0,0,0,.3)),0 0 1px 1px var(--tocsidebar-shadow,rgba(0,0,0,.05));border-radius:2px}
+.dfn-panel:not(.docked)>.caret{position:absolute;top:-9px}
+.dfn-panel:not(.docked)>.caret::after,.dfn-panel:not(.docked)>.caret::before{content:"";position:absolute;border:10px solid transparent;border-top:0;border-bottom:10px solid #fff;border-bottom-color:var(--indextable-hover-bg,#fff);top:0}
+.dfn-panel:not(.docked)>.caret::before{border-bottom:9px solid #a2a9b1;border-bottom-color:var(--indextable-hover-bg,#a2a9b1)}
+.dfn-panel *{margin:0}
+.dfn-panel b{display:block;color:#000;color:var(--text,#000);margin-top:.25em}
+.dfn-panel ul a[href]{color:#333;color:var(--text,#333)}
+.dfn-panel>div{display:flex}
+.dfn-panel a.self-link{font-weight:700;margin-right:auto}
+.dfn-panel .marker{padding:.1em;margin-left:.5em;border-radius:.2em;text-align:center;white-space:nowrap;font-size:90%;color:#040b1c}
+.dfn-panel .marker.dfn-exported{background:#d1edfd;box-shadow:0 0 0 .125em #1ca5f940}
+.dfn-panel .marker.idl-block{background:#8ccbf2;box-shadow:0 0 0 .125em #0670b161}
+.dfn-panel a:not(:hover){text-decoration:none!important;border-bottom:none!important}
+.dfn-panel a[href]:hover{border-bottom-width:1px}
+.dfn-panel ul{padding:0}
+.dfn-panel li{margin-left:1em}
+.dfn-panel.docked{position:fixed;left:.5em;top:unset;bottom:2em;margin:0 auto;max-width:calc(100vw - .75em * 2 - .5em - .2em * 2);max-height:30vh;overflow:auto}
+</style>
+    
+<title>Verifiable Credentials for Recognition v0.9</title>
+    
+    
+    
+<style id="respec-mainstyle">
+@keyframes pop{
+0%{transform:scale(1,1)}
+25%{transform:scale(1.25,1.25);opacity:.75}
+100%{transform:scale(1,1)}
+}
+a.internalDFN{color:inherit;border-bottom:1px solid #99c;text-decoration:none}
+a.externalDFN{color:inherit;border-bottom:1px dotted #ccc;text-decoration:none}
+a.bibref{text-decoration:none}
+.respec-offending-element:target{animation:pop .25s ease-in-out 0s 1}
+.respec-offending-element,a[href].respec-offending-element{text-decoration:red wavy underline}
+@supports not (text-decoration:red wavy underline){
+.respec-offending-element:not(pre){display:inline-block}
+.respec-offending-element{background:url(data:image/gif;base64,R0lGODdhBAADAPEAANv///8AAP///wAAACwAAAAABAADAEACBZQjmIAFADs=) bottom repeat-x}
+}
+#references :target{background:#eaf3ff;animation:pop .4s ease-in-out 0s 1}
+cite .bibref{font-style:italic}
+a[href].orcid{padding-left:4px;padding-right:4px}
+a[href].orcid>svg{margin-bottom:-2px}
+ol.tof,ul.tof{list-style:none outside none}
+.caption{margin-top:.5em;font-style:italic}
+#issue-summary>ul{column-count:2}
+#issue-summary li{list-style:none;display:inline-block}
+details.respec-tests-details{margin-left:1em;display:inline-block;vertical-align:top}
+details.respec-tests-details>*{padding-right:2em}
+details.respec-tests-details[open]{z-index:999999;position:absolute;border:thin solid #cad3e2;border-radius:.3em;background-color:#fff;padding-bottom:.5em}
+details.respec-tests-details[open]>summary{border-bottom:thin solid #cad3e2;padding-left:1em;margin-bottom:1em;line-height:2em}
+details.respec-tests-details>ul{width:100%;margin-top:-.3em}
+details.respec-tests-details>li{padding-left:1em}
+.self-link:hover{opacity:1;text-decoration:none;background-color:transparent}
+aside.example .marker>a.self-link{color:inherit}
+.header-wrapper{display:flex;align-items:baseline}
+:is(h2,h3,h4,h5,h6):not(#toc>h2,#abstract>h2,#sotd>h2,.head>h2){position:relative;left:-.5em}
+:is(h2,h3,h4,h5,h6):not(#toch2)+a.self-link{color:inherit;order:-1;position:relative;left:-1.1em;font-size:1rem;opacity:.5}
+:is(h2,h3,h4,h5,h6)+a.self-link::before{content:"§";text-decoration:none;color:var(--heading-text)}
+:is(h2,h3)+a.self-link{top:-.2em}
+:is(h4,h5,h6)+a.self-link::before{color:#000}
+@media (max-width:767px){
+dd{margin-left:0}
+}
+@media print{
+.removeOnSave{display:none}
+}
+</style>
+    
+    
+<style>
+
+code {
+  color: rgb(199, 73, 0);
+  font-weight: bold;
+}
+pre {
+  overflow-x: auto;
+  white-space: pre-wrap;
+}
+pre .highlight {
+  font-weight: bold;
+  color: Green;
+}
+pre .subject {
+  font-weight: bold;
+  color: RoyalBlue;
+}
+pre .property {
+  font-weight: bold;
+  color: DarkGoldenrod;
+}
+pre .comment {
+  font-weight: bold;
+  color: SteelBlue;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.color-text {
+  font-weight: bold;
+  text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
+}
+ol.algorithm {
+  counter-reset: numsection;
+  list-style-type: none;
+}
+ol.algorithm li {
+  margin: 0.5em 0;
+}
+ol.algorithm li:before {
+  font-weight: bold;
+  counter-increment: numsection;
+  content: counters(numsection, ".") ") ";
+}
+.supported {
+  background-color: #93c47d;
+}
+.missing {
+  background-color: #e06666;
+}
+table.simple {
+    border-collapse: collapse;
+    margin: 25px 0;
+    min-width: 400px;
+    border: 1px solid #dddddd;
+}
+table.simple thead tr {
+    background-color: #005a9c;
+    color: #ffffff;
+    text-align: left;
+}
+table.simple th,
+table.simple td {
+    padding: 12px 15px;
+    vertical-align: top;
+    text-align: left;
+}
+table.simple tbody tr {
+    border-bottom: 1px solid #dddddd;
+}
+table.simple tbody tr:nth-of-type(even) {
+    background-color: #00000008;
+}
+table.simple tbody tr:last-of-type {
+    border-bottom: 2px solid #005a9c;
+}
+    
+</style>
+  
+<meta name="color-scheme" content="light">
+<meta name="description" content="This specification describes a data model with which one or more recognized
+entities, such as one or more persons and/or organizations, can be described as
+known to perform specific actions, such as issuing or verifying a verifiable credential. The data model enables the publication or direct sharing of such
+information, providing a cryptographically-verifiable and privacy-preserving
+mechanism through which a holder can demonstrate that an entity whose
+credential they are using is recognized within a particular ecosystem. The
+specification is designed to interoperate with existing &quot;trust infrastructures&quot;,
+such as X.509 certificate authority lists and ETSI Trust Service Lists, while
+enabling new decentralized ecosystems to be built using verifiable credentials.">
+<link rel="canonical" href="https://www.w3.org/community/reports/credentials/CG-FINAL-vc-recognition-YYYYMMDD/">
+<style>
+.hljs{--base:#fafafa;--mono-1:#383a42;--mono-2:#686b77;--mono-3:#717277;--hue-1:#0b76c5;--hue-2:#336ae3;--hue-3:#a626a4;--hue-4:#42803c;--hue-5:#ca4706;--hue-5-2:#c91243;--hue-6:#986801;--hue-6-2:#9a6a01}
+@media (prefers-color-scheme:dark){
+.hljs{--base:#282c34;--mono-1:#abb2bf;--mono-2:#818896;--mono-3:#5c6370;--hue-1:#56b6c2;--hue-2:#61aeee;--hue-3:#c678dd;--hue-4:#98c379;--hue-5:#e06c75;--hue-5-2:#be5046;--hue-6:#d19a66;--hue-6-2:#e6c07b}
+}
+.hljs{display:block;overflow-x:auto;padding:.5em;color:#383a42;color:var(--mono-1,#383a42);background:#fafafa;background:var(--base,#fafafa)}
+.hljs-comment,.hljs-quote{color:#717277;color:var(--mono-3,#717277);font-style:italic}
+.hljs-doctag,.hljs-formula,.hljs-keyword{color:#a626a4;color:var(--hue-3,#a626a4)}
+.hljs-deletion,.hljs-name,.hljs-section,.hljs-selector-tag,.hljs-subst{color:#ca4706;color:var(--hue-5,#ca4706);font-weight:700}
+.hljs-literal{color:#0b76c5;color:var(--hue-1,#0b76c5)}
+.hljs-addition,.hljs-attribute,.hljs-meta-string,.hljs-regexp,.hljs-string{color:#42803c;color:var(--hue-4,#42803c)}
+.hljs-built_in,.hljs-class .hljs-title{color:#9a6a01;color:var(--hue-6-2,#9a6a01)}
+.hljs-attr,.hljs-number,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-pseudo,.hljs-template-variable,.hljs-type,.hljs-variable{color:#986801;color:var(--hue-6,#986801)}
+.hljs-bullet,.hljs-link,.hljs-meta,.hljs-selector-id,.hljs-symbol,.hljs-title{color:#336ae3;color:var(--hue-2,#336ae3)}
+.hljs-emphasis{font-style:italic}
+.hljs-strong{font-weight:700}
+.hljs-link{text-decoration:underline}
+</style>
+<style>
+var:hover{text-decoration:underline;cursor:pointer}
+var.respec-hl{color:var(--color,#000);background-color:var(--bg-color);box-shadow:0 0 0 2px var(--bg-color)}
+@media (prefers-color-scheme:dark){
+var.respec-hl{filter:saturate(.9) brightness(.9)}
+}
+var.respec-hl-c1{--bg-color:#f4d200}
+var.respec-hl-c2{--bg-color:#ff87a2}
+var.respec-hl-c3{--bg-color:#96e885}
+var.respec-hl-c4{--bg-color:#3eeed2}
+var.respec-hl-c5{--bg-color:#eacfb6}
+var.respec-hl-c6{--bg-color:#82ddff}
+var.respec-hl-c7{--bg-color:#ffbcf2}
+@media print{
+var.respec-hl{background:0 0;color:#000;box-shadow:unset}
+}
+</style>
+<style>
+var{position:relative;cursor:pointer}
+var[data-type]::after,var[data-type]::before{position:absolute;left:50%;top:-6px;opacity:0;transition:opacity .4s;pointer-events:none}
+var[data-type]::before{content:"";transform:translateX(-50%);border-width:4px 6px 0 6px;border-style:solid;border-color:transparent;border-top-color:#222}
+var[data-type]::after{content:attr(data-type);transform:translateX(-50%) translateY(-100%);background:#222;text-align:center;font-family:"Dank Mono","Fira Code",monospace;font-style:normal;padding:6px;border-radius:3px;color:#daca88;text-indent:0;font-weight:400}
+var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
+</style>
+<script id="initialUserConfig" type="application/json">{
+  "specStatus": "CG-FINAL",
+  "shortName": "vc-recognition",
+  "group": "credentials",
+  "edDraftURI": "https://github.com/w3c-ccg/vc-recognition/",
+  "latestVersion": "https://www.w3.org/community/reports/credentials/CG-FINAL-vc-recognition-YYYYMMDD/",
+  "editors": [
+    {
+      "name": "Isaac Henderson Johnson Jeyakumar v0.1,0.2",
+      "company": "Fraunhofer IAO, Germany"
+    },
+    {
+      "name": "David Chadwick v0.2",
+      "company": "Truetrust Ltd"
+    },
+    {
+      "name": "Manu Sporny v0.1",
+      "company": "Digital Bazaar"
+    }
+  ],
+  "authors": [
+    {
+      "name": "Isaac Henderson Johnson Jeyakumar v0.1, v0.2",
+      "company": "Fraunhofer IAO, Germany"
+    },
+    {
+      "name": "David Chadwick v0.2",
+      "company": "Truetrust Ltd"
+    },
+    {
+      "name": "Manu Sporny v0.1",
+      "company": "Digital Bazaar"
+    },
+    {
+      "name": "Oskar van Deventer v0.1",
+      "company": "TNO"
+    },
+    {
+      "name": "Shigeya Suzuki v0.1",
+      "company": "Keio University"
+    },
+    {
+      "name": "Konstantin Tsabolov v0.1",
+      "company": "Spherity"
+    },
+    {
+      "name": "Line Kofoed v0.1",
+      "company": "Bloqzone"
+    },
+    {
+      "name": "Rieks Joosten v0.1",
+      "company": "TNO"
+    }
+  ],
+  "wg": "Credentials Community Group",
+  "wgURI": "https://www.w3.org/community/credentials/",
+  "wgPublicList": "public-credentials",
+  "wgPatentURI": "https://www.w3.org/community/about/agreements/cla/",
+  "github": "https://github.com/w3c-ccg/verifiable-issuers-verifiers/",
+  "maxTocLevel": 4,
+  "xref": [
+    "URL",
+    "I18N-GLOSSARY",
+    "INFRA",
+    "CID",
+    "VC-DATA-MODEL"
+  ],
+  "localBiblio": {
+    "ETSI-TRUST-LISTS": {
+      "title": "Electronic Signatures and Infrastructures (ESI); Trusted Lists",
+      "href": [
+        "https://www.etsi.org/deliver/etsi_ts/119600_119699/119612/02.01.01_60/ts_119612v020101p.pdf"
+      ],
+      "authors": [
+        "ETSI"
+      ],
+      "status": "ETSI Standard TS 119 612 V2.1.1 (2015-07)",
+      "publisher": "ETSI",
+      "id": "etsi-trust-lists"
+    }
+  },
+  "publishISODate": "2026-03-20T00:00:00.000Z",
+  "generatedSubtitle": "Final Community Group Report 20 March 2026"
+}</script>
+<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/cg-final"></head>
+  <body class="h-entry" data-cite="URL I18N-GLOSSARY INFRA CID VC-DATA-MODEL"><div class="head">
+    
+    <h1 id="title" class="title">Verifiable Credentials for Recognition v0.9</h1> 
+    <p id="w3c-state">
+      <a href="https://www.w3.org/standards/types#reports">Final Community Group Report</a>
+      <time class="dt-published" datetime="2026-03-20">20 March 2026</time>
+    </p>
+    <dl>
+      <dt>This version:</dt><dd>
+              <a class="u-url" href="https://www.w3.org/community/reports/credentials/CG-FINAL-vc-recognition-20260320/">https://www.w3.org/community/reports/credentials/CG-FINAL-vc-recognition-20260320/</a>
+            </dd>
+      <dt>Latest published version:</dt><dd>
+              <a href="https://www.w3.org/community/reports/credentials/CG-FINAL-vc-recognition-YYYYMMDD/">https://www.w3.org/community/reports/credentials/CG-FINAL-vc-recognition-YYYYMMDD/</a>
+            </dd>
+      <dt>Latest editor's draft:</dt><dd><a href="https://github.com/w3c-ccg/vc-recognition/">https://github.com/w3c-ccg/vc-recognition/</a></dd>
+      
+      
+      
+      
+      <dt>Editors:</dt><dd class="editor p-author h-card vcard">
+    <span class="p-name fn">Isaac Henderson Johnson Jeyakumar v0.1,0.2</span> (<span class="p-org org h-org">Fraunhofer IAO, Germany</span>)
+  </dd><dd class="editor p-author h-card vcard">
+    <span class="p-name fn">David Chadwick v0.2</span> (<span class="p-org org h-org">Truetrust Ltd</span>)
+  </dd><dd class="editor p-author h-card vcard">
+    <span class="p-name fn">Manu Sporny v0.1</span> (<span class="p-org org h-org">Digital Bazaar</span>)
+  </dd>
+      
+      <dt>Authors:</dt><dd class="editor p-author h-card vcard">
+    <span class="p-name fn">Isaac Henderson Johnson Jeyakumar v0.1, v0.2</span> (<span class="p-org org h-org">Fraunhofer IAO, Germany</span>)
+  </dd><dd class="editor p-author h-card vcard">
+    <span class="p-name fn">David Chadwick v0.2</span> (<span class="p-org org h-org">Truetrust Ltd</span>)
+  </dd><dd class="editor p-author h-card vcard">
+    <span class="p-name fn">Manu Sporny v0.1</span> (<span class="p-org org h-org">Digital Bazaar</span>)
+  </dd><dd class="editor p-author h-card vcard">
+    <span class="p-name fn">Oskar van Deventer v0.1</span> (<span class="p-org org h-org">TNO</span>)
+  </dd><dd class="editor p-author h-card vcard">
+    <span class="p-name fn">Shigeya Suzuki v0.1</span> (<span class="p-org org h-org">Keio University</span>)
+  </dd><dd class="editor p-author h-card vcard">
+    <span class="p-name fn">Konstantin Tsabolov v0.1</span> (<span class="p-org org h-org">Spherity</span>)
+  </dd><dd class="editor p-author h-card vcard">
+    <span class="p-name fn">Line Kofoed v0.1</span> (<span class="p-org org h-org">Bloqzone</span>)
+  </dd><dd class="editor p-author h-card vcard">
+    <span class="p-name fn">Rieks Joosten v0.1</span> (<span class="p-org org h-org">TNO</span>)
+  </dd>
+      <dt>Feedback:</dt><dd>
+        <a href="https://github.com/w3c-ccg/verifiable-issuers-verifiers/">GitHub w3c-ccg/verifiable-issuers-verifiers</a>
+        (<a href="https://github.com/w3c-ccg/verifiable-issuers-verifiers/pulls/">pull requests</a>,
+        <a href="https://github.com/w3c-ccg/verifiable-issuers-verifiers/issues/new/choose">new issue</a>,
+        <a href="https://github.com/w3c-ccg/verifiable-issuers-verifiers/issues/">open issues</a>)
+      </dd><dd><a href="mailto:public-credentials@w3.org?subject=%5Bvc-recognition%5D%20YOUR%20TOPIC%20HERE">public-credentials@w3.org</a> with subject line <kbd>[vc-recognition] <em>… message topic …</em></kbd> (<a rel="discussion" href="https://lists.w3.org/Archives/Public/public-credentials">archives</a>)</dd>
+      
+    </dl>
+    
+    <p class="copyright">
+          <a href="https://www.w3.org/policies/#copyright">Copyright</a>
+          ©
+          2026
+          
+          the Contributors to the Verifiable Credentials for Recognition v0.9
+          Specification, published by the
+          <a href="https://www.w3.org/groups/cg/credentials">Credentials Community Group</a> under the
+          <a href="https://www.w3.org/community/about/agreements/fsa/">W3C Community Final Specification Agreement (FSA)</a>. A human-readable
+                <a href="https://www.w3.org/community/about/agreements/fsa-deed/">summary</a>
+                is available.
+              
+        </p>
+    <hr title="Separator for header">
+  </div>
+    <section id="abstract" class="introductory"><h2>Abstract</h2>
+      <p>
+This specification describes a data model with which one or more recognized
+entities, such as one or more persons and/or organizations, can be described as
+known to perform specific actions, such as issuing or verifying a <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-credential">verifiable credential</a>. The data model enables the publication or direct sharing of such
+information, providing a cryptographically-verifiable and privacy-preserving
+mechanism through which a <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-holders">holder</a> can demonstrate that an entity whose
+credential they are using is recognized within a particular ecosystem. The
+specification is designed to interoperate with existing "trust infrastructures",
+such as X.509 certificate authority lists and ETSI Trust Service Lists, while
+enabling new decentralized ecosystems to be built using <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-credential">verifiable credentials</a>.
+      </p>
+    </section>
+
+    <section id="sotd" class="introductory"><h2>Status of This Document</h2><p>
+      This specification was published by the
+      <a href="https://www.w3.org/groups/cg/credentials">Credentials Community Group</a>. It is not a W3C Standard nor is it
+      on the W3C Standards Track.
+      
+            Please note that under the
+            <a href="https://www.w3.org/community/about/agreements/final/">W3C Community Final Specification Agreement (FSA)</a>
+            other conditions apply.
+          
+      Learn more about
+      <a href="https://www.w3.org/community/">W3C Community and Business Groups</a>.
+    </p>
+
+      <p>
+This is an experimental specification and is undergoing regular revisions. It is
+not fit for production deployment.
+      </p>
+
+    <p>
+    <a href="https://github.com/w3c-ccg/verifiable-issuers-verifiers/issues/">GitHub Issues</a> are preferred for
+          discussion of this specification.
+        
+    Alternatively, you can send comments to our mailing list.
+          Please send them to
+          <a href="mailto:public-credentials@w3.org">public-credentials@w3.org</a>
+          (<a href="mailto:public-credentials-request@w3.org?subject=subscribe">subscribe</a>,
+          <a href="https://lists.w3.org/Archives/Public/public-credentials/">archives</a>).
+        
+  </p></section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a class="tocxref" href="#abstract">Abstract</a></li><li class="tocline"><a class="tocxref" href="#sotd">Status of This Document</a></li><li class="tocline"><a class="tocxref" href="#introduction"><bdi class="secno">1. </bdi>Introduction</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#conformance"><bdi class="secno">1.1 </bdi>Conformance</a></li></ol></li><li class="tocline"><a class="tocxref" href="#data-model"><bdi class="secno">2. </bdi>Data Model</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#general-properties"><bdi class="secno">2.1 </bdi>General Properties</a></li><li class="tocline"><a class="tocxref" href="#recognizedentity"><bdi class="secno">2.2 </bdi>RecognizedEntity</a></li><li class="tocline"><a class="tocxref" href="#recognizedaction"><bdi class="secno">2.3 </bdi>RecognizedAction</a></li><li class="tocline"><a class="tocxref" href="#verifiablerecognitioncredential"><bdi class="secno">2.4 </bdi>VerifiableRecognitionCredential</a></li></ol></li><li class="tocline"><a class="tocxref" href="#privacy-considerations"><bdi class="secno">3. </bdi>Privacy Considerations</a></li><li class="tocline"><a class="tocxref" href="#security-considerations"><bdi class="secno">4. </bdi>Security Considerations</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#validate-before-sharing"><bdi class="secno">4.1 </bdi>Validate Before Sharing</a></li></ol></li><li class="tocline"><a class="tocxref" href="#acknowledgements"><bdi class="secno">A. </bdi>Acknowledgements</a></li><li class="tocline"><a class="tocxref" href="#references"><bdi class="secno">B. </bdi>References</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><bdi class="secno">B.1 </bdi>Normative references</a></li></ol></li></ol></nav>
+
+    <section id="introduction"><div class="header-wrapper"><h2 id="x1-introduction"><bdi class="secno">1. </bdi>Introduction</h2><a class="self-link" href="#introduction" aria-label="Permalink for Section 1."></a></div>
+      
+
+      <p>
+The <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-credential">verifiable credential</a> ecosystem relies on the ability of <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier">verifiers</a>
+to determine whether a particular <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers">issuer</a> is recognized to perform a
+particular action, such as <a data-link-type="dfn" data-lt="issuer" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers">issuing</a> a certain type of <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-credential">verifiable credential</a>. Historically, this determination has often been made through
+out-of-band processes, bilateral agreements, or proprietary registries that are
+difficult to discover, query, or reason about in an automated way. As <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-credential">verifiable credentials</a> are increasingly deployed across sectors such as education, healthcare,
+financial services, and government, the need for a standardized, interoperable
+mechanism to express and communicate recognition of entities that perform known
+actions has become critical. Without such a mechanism, ecosystem participants
+are forced to build bespoke "trust infrastructure", leading to fragmentation,
+increased integration costs, and barriers to cross-border and cross-sector
+interoperability.
+      </p>
+
+      <p>
+This specification addresses the challenge of expressing recognized entities,
+such as people and organizations, and the actions they perform, such as issuing
+and verifying, in a decentralized manner by defining a data model that any
+entity can use to publish or share recognition information as a <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-credential">verifiable credential</a>. Rather than mandating a single central registry, the model allows
+any entity — a government body, an industry consortium, a standards
+organization, or even a single individual — to issue a
+<code>VerifiableRecognitionCredential</code> asserting that they know of one or more
+entities that are recognized to perform specific actions. This design enables a
+web of overlapping, competing, and complementary "trust registries" to coexist,
+allowing ecosystem participants to choose the entities they trust and to reason
+across multiple registries. The specification also supports interoperability
+with existing "trust infrastructure", such as X.509 certificate authority lists
+and ETSI Trust Service Lists, allowing existing recognized entity information to
+be referenced and composed into new decentralized ecosystems.
+      </p>
+
+      <p>
+Readers who are interested in the variety of use cases supported by this
+
+specification are urged to read the
+<a href="use-cases.html">use cases document</a>. The remainder of this document
+is organized into the following sections:
+      </p>
+
+      <ul>
+        <li>
+Section <a href="#data-model" data-matched-text="[[[#data-model]]]" class="sec-ref"><bdi class="secno">2. </bdi>Data Model</a> defines the core data model, including the
+<code>RecognizedEntity</code>, <code>RecognizedAction</code>, and <code>VerifiableRecognitionCredential</code>
+types along with their properties and worked examples.
+        </li>
+        <li>
+Section <a href="#security-considerations" data-matched-text="[[[#security-considerations]]]" class="sec-ref"><bdi class="secno">4. </bdi>Security Considerations</a> discusses security considerations
+relevant to implementers of this specification.
+        </li>
+        <li>
+Section <a href="#privacy-considerations" data-matched-text="[[[#privacy-considerations]]]" class="sec-ref"><bdi class="secno">3. </bdi>Privacy Considerations</a> discusses privacy considerations
+relevant to implementers of this specification.
+        </li>
+      </ul>
+
+      <section id="conformance"><div class="header-wrapper"><h3 id="x1-1-conformance"><bdi class="secno">1.1 </bdi>Conformance</h3><a class="self-link" href="#conformance" aria-label="Permalink for Section 1.1"></a></div><p>As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.</p><p>
+        The key words <em class="rfc2119">MAY</em>, <em class="rfc2119">MUST</em>, <em class="rfc2119">OPTIONAL</em>, and <em class="rfc2119">SHOULD</em> in this document
+        are to be interpreted as described in
+        <a href="https://www.rfc-editor.org/info/bcp14">BCP 14</a>
+        [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2119" title="Key words for use in RFCs to Indicate Requirement Levels">RFC2119</a></cite>] [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8174" title="Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words">RFC8174</a></cite>]
+        when, and only when, they appear in all
+        capitals, as shown here.
+      </p>
+        <p>
+A <dfn id="dfn-conforming-document" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">conforming document</dfn> is any concrete expression of the data model
+that complies with the normative statements in this specification. Specifically,
+all relevant normative statements in Section
+<a href="#data-model" class="sec-ref"><bdi class="secno">2. </bdi>Data Model</a> of this document <em class="rfc2119">MUST</em> be enforced.
+        </p>
+
+        <p>
+A <dfn class="lint-ignore" id="dfn-conforming-processor" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">conforming processor</dfn> is any algorithm realized
+as software and/or hardware that generates or consumes a
+<a href="#dfn-conforming-document" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-conforming-document-1">conforming document</a>. Conforming processors <em class="rfc2119">MUST</em> produce errors when
+non-conforming documents are consumed.
+        </p>
+        <p>
+This document also contains examples that contain JSON and JSON-LD content. Some
+of these examples contain characters that are invalid JSON, such as inline
+comments (<code>//</code>) and the use of ellipsis (<code>...</code>) to denote
+information that adds little value to the example. Implementers are cautioned to
+remove this content if they desire to use the information as valid JSON or
+JSON-LD.
+        </p>
+      </section>
+
+    </section>
+
+    <section id="data-model"><div class="header-wrapper"><h2 id="x2-data-model"><bdi class="secno">2. </bdi>Data Model</h2><a class="self-link" href="#data-model" aria-label="Permalink for Section 2."></a></div>
+      
+
+      <p>
+The following sections outline the data model that is used by this specification
+for Verifiable Issuer and Verifier Lists.
+      </p>
+
+<p>
+The data model described in this section has been built using input from a
+variety of the prior art evaluated for this paper including input from the EBSI
+Trusted Issuer Registry, ETSI TS 119 612, eSSIF-Lab TRAIN, the Trust over IP
+Foundation Trust Registry Protocol, and Rebooting the Web of Trust input
+documents. The data model described in this section is capable of expressing
+many, but not all, of the concepts described in those other specifications.
+</p>
+<p>
+The unified data model for this work can be represented as a list of service providers
+that represent entities or organizations that provide services such as
+credential issuance or validation. The data model also includes the
+details of the list operator description.
+</p>
+
+    <section id="general-properties"><div class="header-wrapper"><h3 id="x2-1-general-properties"><bdi class="secno">2.1 </bdi>General Properties</h3><a class="self-link" href="#general-properties" aria-label="Permalink for Section 2.1"></a></div>
+        
+
+        <p>
+The properties in this section can be added to objects found in a
+<code>VerifiableRecognitionCredential</code> as defined in Section
+<a href="#verifiablerecognitioncredential" data-matched-text="[[[#verifiablerecognitioncredential]]]" class="sec-ref"><bdi class="secno">2.4 </bdi>VerifiableRecognitionCredential</a>. Each general property listed in
+this section is <em class="rfc2119">OPTIONAL</em>; none of the values are required to be provided by
+an <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers">issuer</a>.
+        </p>
+
+        <table class="simple">
+          <thead>
+            <tr>
+              <th style="white-space: nowrap">Property</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>id</td>
+              <td>
+A URL that identifies the entity in a globally unambiguous way. The value for
+this property is defined in
+<a href="https://www.w3.org/TR/vc-data-model-2.0/#identifiers">Section 4.4: Identifiers</a>
+of the <cite><a data-matched-text="[[[VC-DATA-MODEL]]]" href="https://www.w3.org/TR/vc-data-model-2.0/">Verifiable Credentials Data Model v2.0</a></cite> specification.
+              </td>
+            </tr>
+            <tr>
+              <td>type</td>
+              <td>
+The type of the entity. The value for this property is defined in
+<a href="https://www.w3.org/TR/vc-data-model-2.0/#types">Section 4.5: Types</a>
+of the <cite><a data-matched-text="[[[VC-DATA-MODEL]]]" href="https://www.w3.org/TR/vc-data-model-2.0/">Verifiable Credentials Data Model v2.0</a></cite> specification. The <code>type</code> property <em class="rfc2119">MUST</em> be
+<code>RecognizedIssuer</code> if the entity is an <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers">issuer</a> of <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-credential">verifiable credentials</a>.
+              </td>
+            </tr>
+            <tr>
+              <td>name</td>
+              <td>
+A human-readable name for the entity. The value for this property is defined in
+<a href="https://www.w3.org/TR/vc-data-model-2.0/#names-and-descriptions">Section 4.6: Names and Descriptions</a>
+of the <cite><a data-matched-text="[[[VC-DATA-MODEL]]]" href="https://www.w3.org/TR/vc-data-model-2.0/">Verifiable Credentials Data Model v2.0</a></cite> specification.
+              </td>
+            </tr>
+            <tr>
+              <td>legalName</td>
+              <td>
+The official legal name of an organization or entity, as registered with legal
+authorities, which can differ from the commonly used name. The value <em class="rfc2119">MUST</em> be a
+<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string">string</a>.
+              </td>
+            </tr>
+            <tr>
+              <td>image</td>
+              <td>
+A URL or image data representing a visual identifier for the entity, such as a
+logo, photograph, or icon. The value <em class="rfc2119">MUST</em> be a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>.
+              </td>
+            </tr>
+            <tr>
+              <td>url</td>
+              <td>
+A URL pointing to the primary website or web resource associated with the
+entity. The value <em class="rfc2119">MUST</em> be a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>.
+              </td>
+            </tr>
+            <tr>
+              <td>sameAs</td>
+              <td>
+One or more URLs that refer to the same entity in other contexts or systems,
+enabling cross-reference and verification across different platforms.
+Each value <em class="rfc2119">MUST</em> be a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>.
+              </td>
+            </tr>
+            <tr>
+              <td>description</td>
+              <td>
+A human-readable description providing details about the entity. The value for
+this property is defined in
+<a href="https://www.w3.org/TR/vc-data-model-2.0/#names-and-descriptions">Section 4.6: Names and Descriptions</a>
+of the <cite><a data-matched-text="[[[VC-DATA-MODEL]]]" href="https://www.w3.org/TR/vc-data-model-2.0/">Verifiable Credentials Data Model v2.0</a></cite> specification.
+              </td>
+            </tr>
+            <tr>
+              <td>digestMultibase</td>
+              <td>
+One or more cryptographic digests used to verify the integrity of resources
+associated with the entity. The values for this property are defined in
+<a href="https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources">Section 5.3: Integrity of Related Resources</a>
+of the <cite><a data-matched-text="[[[VC-DATA-MODEL]]]" href="https://www.w3.org/TR/vc-data-model-2.0/">Verifiable Credentials Data Model v2.0</a></cite> specification.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+    </section>
+
+    <section id="recognizedentity"><div class="header-wrapper"><h3 id="x2-2-recognizedentity"><bdi class="secno">2.2 </bdi>RecognizedEntity</h3><a class="self-link" href="#recognizedentity" aria-label="Permalink for Section 2.2"></a></div>
+        
+
+        <p>
+A <dfn id="dfn-recognized-entity" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">recognized entity</dfn> is any entity that is recognized by an <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers">issuer</a>
+of a <code>VerifiableRecognitionCredential</code> to perform a specific action.
+        </p>
+
+        <table class="simple">
+          <thead>
+            <tr>
+              <th style="white-space: nowrap">Property</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>id</td>
+              <td>
+A URL that identifies the entity in a globally unambiguous way. The value for
+this property is defined in
+<a href="https://www.w3.org/TR/vc-data-model-2.0/#identifiers">Section 4.4: Identifiers</a>
+of the <cite><a data-matched-text="[[[VC-DATA-MODEL]]]" href="https://www.w3.org/TR/vc-data-model-2.0/">Verifiable Credentials Data Model v2.0</a></cite> specification.
+              </td>
+            </tr>
+            <tr>
+              <td>type</td>
+              <td>
+The <code>type</code> property <em class="rfc2119">MUST</em> be <code>RecognizedEntity</code>. The value for
+this property is defined in
+<a href="https://www.w3.org/TR/vc-data-model-2.0/#types">Section 4.5: Types</a>
+of the <cite><a data-matched-text="[[[VC-DATA-MODEL]]]" href="https://www.w3.org/TR/vc-data-model-2.0/">Verifiable Credentials Data Model v2.0</a></cite> specification.
+              </td>
+            </tr>
+            <tr>
+              <td>recognizedTo</td>
+              <td>
+A specific action that the <a data-link-type="dfn|abstract-op" href="#dfn-recognized-entity" class="internalDFN" id="ref-for-dfn-recognized-entity-1">recognized entity</a> is expected to perform as
+defined in Section <a href="#recognizedaction" data-matched-text="[[[#recognizedaction]]]" class="sec-ref"><bdi class="secno">2.3 </bdi>RecognizedAction</a>. This property may occur more
+than once if the <a data-link-type="dfn|abstract-op" href="#dfn-recognized-entity" class="internalDFN" id="ref-for-dfn-recognized-entity-2">recognized entity</a> is expected to perform more than
+one action.
+              </td>
+            </tr>
+            <tr>
+              <td>recognizedIn</td>
+              <td>
+An object that contains a reference to a document of recognized entities that
+contains this particular <a data-link-type="dfn|abstract-op" href="#dfn-recognized-entity" class="internalDFN" id="ref-for-dfn-recognized-entity-3">recognized entity</a> as well as the actions it is
+known to perform. The <code>id</code> value of the object <em class="rfc2119">MUST</em> be a
+<a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>. The <code>type</code> value of the object <em class="rfc2119">MUST</em> conform to the
+<a href="https://www.w3.org/TR/vc-data-model-2.0/#types">type value space </a> defined in
+the <cite><a data-matched-text="[[[VC-DATA-MODEL]]]" href="https://www.w3.org/TR/vc-data-model-2.0/">Verifiable Credentials Data Model v2.0</a></cite> specification and <em class="rfc2119">SHOULD</em> be <code>EtsiTrustServiceList</code>,
+<code>x509CertificateAuthorityList</code>, or <code>VerifiableRecognitionCredential</code>.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p>
+Properties from Section <a href="#general-properties" data-matched-text="[[[#general-properties]]]" class="sec-ref"><bdi class="secno">2.1 </bdi>General Properties</a> can be included in
+addition to the properties above.
+        </p>
+
+        <p>
+A <code>recognizedIn</code> with a <code>type</code> property of <code>EtsiTrustServiceList</code> <em class="rfc2119">MUST</em> conform
+to the <cite><a data-matched-text="[[[ETSI-TRUST-LISTS]]]" href="https://www.etsi.org/deliver/etsi_ts/119600_119699/119612/02.01.01_60/ts_119612v020101p.pdf">Electronic Signatures and Infrastructures (ESI); Trusted Lists</a></cite> specification. A list with <code>type</code> property of
+<code>x509CertificateAuthorityList</code> <em class="rfc2119">MUST</em> conform to the <cite><a data-matched-text="[[[RFC5280]]]" href="https://www.rfc-editor.org/rfc/rfc5280">Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile</a></cite> specification.
+A list with a <code>type</code> property of <code>VerifiableRecognitionCredential</code> <em class="rfc2119">MUST</em> conform
+to this specification.
+        </p>
+
+    </section>
+
+    <section id="recognizedaction"><div class="header-wrapper"><h3 id="x2-3-recognizedaction"><bdi class="secno">2.3 </bdi>RecognizedAction</h3><a class="self-link" href="#recognizedaction" aria-label="Permalink for Section 2.3"></a></div>
+        
+
+        <p>
+A <dfn id="dfn-recognized-action" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn" class="respec-offending-element" title="Found definition for &quot;recognized action&quot;, but nothing links to it. This is usually a spec bug!">recognized action</dfn> is an action that a <a data-link-type="dfn|abstract-op" href="#dfn-recognized-entity" class="internalDFN" id="ref-for-dfn-recognized-entity-4">recognized entity</a> is
+expected to perform.
+        </p>
+
+        <table class="simple">
+          <thead>
+            <tr>
+              <th style="white-space: nowrap">Property</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>type</td>
+              <td>
+The <code>type</code> property <em class="rfc2119">MUST</em> be <code>RecognizedAction</code>.
+              </td>
+            </tr>
+            <tr>
+              <td>action</td>
+              <td>
+A <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string">string</a> that specifies the name of the action to be performed such as
+<code>issue</code> or <code>verify</code>.
+              </td>
+            </tr>
+            <tr>
+              <td>recognizedBy</td>
+              <td>
+A <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>, or object containing properties from Section
+<a href="#general-properties" data-matched-text="[[[#general-properties]]]" class="sec-ref"><bdi class="secno">2.1 </bdi>General Properties</a>, of the entity that performed the task of recognizing.
+              </td>
+            </tr>
+            <tr>
+              <td>outputValidation</td>
+              <td>
+The value of the <code>outputValidation</code>
+<a href="https://www.w3.org/TR/vc-data-model-2.0/#property">property</a> <em class="rfc2119">MUST</em> be one or more data
+schemas that provide <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier">verifiers</a> with enough information to determine whether
+the provided data conforms to the provided schema(s). Each validator <em class="rfc2119">MUST</em>
+specify its <code>type</code> (for example, <code>JsonSchema</code>) and an <code>id</code>
+<a href="https://www.w3.org/TR/vc-data-model-2.0/#property">property</a> that <em class="rfc2119">MUST</em> be a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>
+identifying the schema file. The specific type definition determines the precise
+contents of each data schema. If multiple schemas are present, validity is
+determined according to the processing rules outlined by each associated <code>type</code>
+property.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+    </section>
+
+    <section id="verifiablerecognitioncredential"><div class="header-wrapper"><h3 id="x2-4-verifiablerecognitioncredential"><bdi class="secno">2.4 </bdi>VerifiableRecognitionCredential</h3><a class="self-link" href="#verifiablerecognitioncredential" aria-label="Permalink for Section 2.4"></a></div>
+        
+
+        <p>
+When a <dfn data-lt="recognition credential|verifiable recognition credential" id="dfn-recognition-credential" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">verifiable recognition credential</dfn>
+is published, it <em class="rfc2119">MUST</em> be a conforming
+<a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-credential">verifiable credential</a>, as defined in <cite><a data-matched-text="[[[VC-DATA-MODEL-2.0]]]" href="https://www.w3.org/TR/vc-data-model-2.0/">Verifiable Credentials Data Model v2.0</a></cite>, that
+expresses the data model specified in the section that follows. It describes
+the format of a <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-credential">verifiable credential</a> that encapsulates the recognized
+entities.
+        </p>
+
+        <p>
+A recognized entity is expressed inside a <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-credential">verifiable credential</a>,
+enabling a <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-holders">holder</a> to provide it directly to a <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier">verifier</a>. This
+mechanism, sometimes called "certificate stapling", increases privacy for the
+<a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-holders">holder</a> by ensuring that the <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier">verifier</a> does not need to contact the
+<a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers">issuer</a> to retrieve the recognition credential. Still, a <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier">verifier</a> might
+choose to ignore the <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-holders">holder</a>-provided <a data-link-type="dfn|abstract-op" href="#dfn-recognition-credential" class="internalDFN" id="ref-for-dfn-recognition-credential-1">recognition credential</a>, even when
+its authenticity is verifiable, if, for instance, it desires a more recent
+version of the <a data-link-type="dfn|abstract-op" href="#dfn-recognition-credential" class="internalDFN" id="ref-for-dfn-recognition-credential-2">recognition credential</a>.
+        </p>
+
+        <table class="simple">
+          <thead>
+            <tr>
+              <th style="white-space: nowrap">Property</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>id</td>
+              <td>
+A <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-credential">verifiable credential</a> that contains a set of recognized entities <em class="rfc2119">MAY</em>
+express an <code>id</code> property to make its retrieval easier for other systems.
+              </td>
+            </tr>
+            <tr>
+              <td>type</td>
+              <td>
+A <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-credential">verifiable credential</a> that contains a set of recognized entities <em class="rfc2119">MUST</em>
+express a <code>type</code> property that includes the <code>VerifiableRecognitionCredential</code>
+value.
+              </td>
+            </tr>
+            <tr>
+              <td>issuer</td>
+              <td>
+The <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers">issuer</a> of the <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-credential">verifiable credential</a> as
+defined in the Verifiable Credentials Data Model specification in
+<a href="https://www.w3.org/TR/vc-data-model-2.0/#issuer">
+Section 4.76: Issuer</a>. This object <em class="rfc2119">MAY</em> also include other properties listed
+in Section <a href="#general-properties" data-matched-text="[[[#general-properties]]]" class="sec-ref"><bdi class="secno">2.1 </bdi>General Properties</a>.
+              </td>
+            </tr>
+            <tr>
+              <td>validFrom</td>
+              <td>
+The earliest point in time at which the credential is valid. This property is
+defined in the Verifiable Credentials Data Model specification in
+<a href="https://www.w3.org/TR/vc-data-model-2.0/#validity-period">
+Section 4.6: Validity Period</a>.
+              </td>
+            </tr>
+            <tr>
+              <td>validUntil</td>
+              <td>
+The latest point in time at which the credential is valid. This property is
+defined in the Verifiable Credentials Data Model specification in
+<a href="https://www.w3.org/TR/vc-data-model-2.0/#validity-period">
+Section 4.6: Validity Period</a>.
+              </td>
+            </tr>
+            <tr>
+              <td>credentialSubject</td>
+              <td>
+A set of one or more <code>RecognizedEntity</code> objects as defined in
+Section <a href="#recognizedentity" data-matched-text="[[[#recognizedentity]]]" class="sec-ref"><bdi class="secno">2.2 </bdi>RecognizedEntity</a>.
+              </td>
+            </tr>
+        </tbody>
+      </table>
+
+      <p>
+The following examples demonstrate how verifiable recognition credentials can be
+employed in a variety of use cases. The first example below is used to
+publish information about a set of known universities in a particular nation.
+      </p>
+
+      <div class="example" id="example-a-set-of-known-universities-in-a-particular-nation">
+        <div class="marker">
+    <a class="self-link" href="#example-a-set-of-known-universities-in-a-particular-nation">Example<bdi> 1</bdi></a><span class="example-title">: A set of known universities in a particular nation</span>
+  </div> <pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"@context"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span>
+    <span class="hljs-string">"https://www.w3.org/ns/credentials/v2"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-string">"https://www.w3.org/ns/credentials/examples/v2"</span>
+  <span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span>
+    <span class="hljs-string">"VerifiableCredential"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-string">"VerifiableRecognitionCredential"</span>
+  <span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"issuer"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:web:learning-commission.example"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"RecognizedIssuer"</span>
+  <span class="hljs-punctuation">}</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"validFrom"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2025-01-01T00:00:00Z"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"validUntil"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2030-01-01T00:00:00Z"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"credentialSubject"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:web:university.example"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"RecognizedEntity"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"Example Tech"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"legalName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"Example Polytechnic University"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"image"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://university.example/logo.png"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://www.university.example/"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"A university providing a great education in Utopia Valley."</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-punctuation">}</span><span class="hljs-punctuation">,</span> <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:web:college.example"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"RecognizedEntity"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"Exemplar Community College"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"legalName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"Community College of Examples and "</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"image"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://college.example/graphics/ecc.png"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://college.example/"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"The backbone of learning in the Utopia community."</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-punctuation">}</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"proof"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"DataIntegrityProof"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"created"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2026-04-10T20:08:22Z"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"verificationMethod"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:web:accreditor.example#issuance-key-1"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"cryptosuite"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ecdsa-rdfc-2019"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"proofPurpose"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"assertionMethod"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"proofValue"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"z36XPGByaH3rvtKfwoEQXsnUXUAjwd2Ceiqke1GPfjAPAFYoXKo5ftPdwE7QZ8Mw22SC5LSRQg1d8bhe3252hYJoH"</span>
+  <span class="hljs-punctuation">}</span>
+<span class="hljs-punctuation">}</span></code></pre>
+      </div>
+
+      <p>
+The next example is used to publish information about a set of known issuers
+for a particular type of <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-credential">verifiable credential</a>.
+      </p>
+
+      <div class="example" id="example-a-set-of-known-issuers-for-a-particular-type-of-credential">
+        <div class="marker">
+    <a class="self-link" href="#example-a-set-of-known-issuers-for-a-particular-type-of-credential">Example<bdi> 2</bdi></a><span class="example-title">: A set of known issuers for a particular type of credential</span>
+  </div> <pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"@context"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span>
+    <span class="hljs-string">"https://www.w3.org/ns/credentials/v2"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-string">"https://www.w3.org/ns/credentials/examples/v2"</span>
+  <span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span>
+    <span class="hljs-string">"VerifiableCredential"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-string">"VerifiableRecognitionCredential"</span>
+  <span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"issuer"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:web:learning-commission.example"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"RecognizedIssuer"</span>
+  <span class="hljs-punctuation">}</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"validFrom"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2025-01-01T00:00:00Z"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"validUntil"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2030-01-01T00:00:00Z"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"credentialSubject"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:web:university.example"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"RecognizedEntity"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"Example Tech"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"legalName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"Example Polytechnic University"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"image"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://university.example/logo.png"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://www.university.example/"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"A university providing a great education in Utopia Valley."</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"recognizedTo"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+      <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"RecognizedAction"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"action"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"issue"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"recognizedBy"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:web:learning-commission.example"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"outputValidation"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+        <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://learning-commission.example/credentials/bachelors.json"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"JsonSchema"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"digestMultibase"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"uEiBZl963sknNAHgPyslVv6VztZpfWQoRvW1htfx-UwirFo"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-punctuation">}</span>
+    <span class="hljs-punctuation">}</span>
+  <span class="hljs-punctuation">}</span><span class="hljs-punctuation">,</span> <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:web:college.example"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"RecognizedEntity"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"Exemplar Community College"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"legalName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"Community College of Examples and "</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"image"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://college.example/graphics/ecc.png"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://college.example/"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"description"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"The backbone of learning in the Utopia community."</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"recognizedTo"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+      <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"RecognizedAction"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"action"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"issue"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"recognizedBy"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:web:learning-commission.example"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"outputValidation"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+        <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://learning-commission.example/credentials/associates.json"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"JsonSchema"</span><span class="hljs-punctuation">,</span>
+        <span class="hljs-attr">"digestMultibase"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"uEiWQoRvpfWW1htfsknNAHgPyslVv6VztZpfwirFoBZl963"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-punctuation">}</span>
+    <span class="hljs-punctuation">}</span>
+  <span class="hljs-punctuation">}</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"proof"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"DataIntegrityProof"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"created"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2026-04-10T20:08:22Z"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"verificationMethod"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:web:accreditor.example#issuance-key-1"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"cryptosuite"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ecdsa-rdfc-2019"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"proofPurpose"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"assertionMethod"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"proofValue"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"z36XPGByaH3rvtKfwoEQXsnUXUAjwd2Ceiqke1GPfjAPAFYoXKo5ftPdwE7QZ8Mw22SC5LSRQg1d8bhe3252hYJoH"</span>
+  <span class="hljs-punctuation">}</span>
+<span class="hljs-punctuation">}</span></code></pre>
+      </div>
+
+      <p>
+The final example below is used to publish information about an entity that
+publishes an European Union ETSI Trust Services list [<cite><a class="bibref" data-link-type="biblio" href="#bib-etsi-trust-lists" title="Electronic Signatures and Infrastructures (ESI); Trusted Lists">ETSI-TRUST-LISTS</a></cite>].
+      </p>
+
+      <div class="example" id="example-an-entity-that-publishes-information-conforming-to-an-eu-etsi-trust-service-list">
+        <div class="marker">
+    <a class="self-link" href="#example-an-entity-that-publishes-information-conforming-to-an-eu-etsi-trust-service-list">Example<bdi> 3</bdi></a><span class="example-title">: An entity that publishes information conforming to an EU ETSI Trust Service list</span>
+  </div> <pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"@context"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span>
+    <span class="hljs-string">"https://www.w3.org/ns/credentials/v2"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-string">"https://www.w3.org/ns/credentials/examples/v2"</span>
+  <span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span>
+    <span class="hljs-string">"VerifiableCredential"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-string">"VerifiableRecognitionCredential"</span>
+  <span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"issuer"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:web:ec.europa.example"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"validFrom"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2025-01-01T00:00:00Z"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"validUntil"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2030-01-01T00:00:00Z"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"credentialSubject"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:web:ec.europa.example"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"RecognizedEntity"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"Utopian Commission"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"legalName"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"The Utopian Commission"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"image"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://ec.europa.example/logo.png"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"url"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://ec.europa.example/"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"recognizedIn"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+      <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://ec.europa.example/tsl/lotl.xml"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"EtsiTrustServiceList"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"name"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"Utopian Commission List of the Lists"</span>
+    <span class="hljs-punctuation">}</span>
+  <span class="hljs-punctuation">}</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"proof"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"DataIntegrityProof"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"created"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2026-04-10T20:08:22Z"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"verificationMethod"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:web:ec.europa.example#issuance-key-1"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"cryptosuite"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ecdsa-rdfc-2019"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"proofPurpose"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"assertionMethod"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"proofValue"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"z36XPGByaH3rvtKfwoEQXsnUXUAjwd2Ceiqke1GPfjAPAFYoXKo5ftPdwE7QZ8Mw22SC5LSRQg1d8bhe3252hYJoH"</span>
+  <span class="hljs-punctuation">}</span>
+<span class="hljs-punctuation">}</span></code></pre>
+      </div>
+
+    </section>
+    </section>
+
+    <section id="privacy-considerations"><div class="header-wrapper"><h2 id="x3-privacy-considerations"><bdi class="secno">3. </bdi>Privacy Considerations</h2><a class="self-link" href="#privacy-considerations" aria-label="Permalink for Section 3."></a></div>
+      
+
+      <p>
+This section details the general privacy considerations and specific privacy
+implications of deploying this specification into production environments.
+      </p>
+
+      <p>
+Readers are urged to familiarize themselves with the general privacy advice
+provided in the
+<a href="https://www.w3.org/TR/vc-data-model-2.0/#privacy-considerations">
+Privacy Considerations section of the Verifiable Credentials specification</a>
+before reading this section.
+      </p>
+    </section>
+
+    <section id="security-considerations"><div class="header-wrapper"><h2 id="x4-security-considerations"><bdi class="secno">4. </bdi>Security Considerations</h2><a class="self-link" href="#security-considerations" aria-label="Permalink for Section 4."></a></div>
+      
+
+      <p>
+There are a number of security considerations that implementers should be
+aware of when processing data described by this specification. Ignoring or
+not understanding the implications of this section can result in
+security vulnerabilities.
+      </p>
+
+      <p>
+Readers are urged to familiarize themselves with the general
+security advice provided in the
+<a href="https://www.w3.org/TR/vc-data-model-2.0/#security-considerations">
+Security Considerations section of the Verifiable Credentials
+specification</a> before reading this section.
+      </p>
+
+      <p>
+While this section attempts to highlight a broad set of security
+considerations, it is not a complete list. Implementers are urged to seek the
+advice of security and cryptography professionals when implementing mission
+critical systems using the technology outlined in this specification.
+      </p>
+
+      <section id="validate-before-sharing"><div class="header-wrapper"><h3 id="x4-1-validate-before-sharing"><bdi class="secno">4.1 </bdi>Validate Before Sharing</h3><a class="self-link" href="#validate-before-sharing" aria-label="Permalink for Section 4.1"></a></div>
+        
+        <p>
+When a <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-holders">holder</a> receives a <code>VerifiableRecognitionCredential</code> and shares it
+with others, there is a risk that the credential has not been properly vetted.
+A malicious or negligent actor could craft a <code>VerifiableRecognitionCredential</code>
+that lists fraudulent or compromised entities as recognized issuers or
+verifiers, and propagate it peer-to-peer across an ecosystem. Recipients who
+accept and act upon such a credential without independent verification might
+unknowingly accept <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-credential">verifiable credentials</a> from untrustworthy sources,
+exposing themselves and others to fraud, data breaches, or credential
+forgery. The decentralized nature of this specification, while a strength,
+amplifies this risk: a single unvetted credential shared widely can rapidly
+corrupt the trust assumptions of many parties in an ecosystem.
+        </p>
+        <p>
+To mitigate these dangers, deployments are expected to independently verify the
+cryptographic integrity and provenance of any <code>VerifiableRecognitionCredential</code>
+before acting upon it or sharing it further. This includes confirming that the
+<a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers">issuer</a> of the credential is a party the implementer has an established
+reason to trust for the given recognition domain, and that the credential has
+not expired or been revoked. Implementers cannot rely solely on the fact
+that a peer has already accepted a credential as evidence of its validity.
+Instead, a <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier">verifier</a> needs to vet the issuer of the recognition credential
+as well as the recognized action independently of receiving the
+<code>VerifiableRecognitionCredential</code> and can only depend on information from the
+credential once trust has been established on the issuing entity.
+        </p>
+      </section>
+
+    </section>
+
+    <section class="appendix informative" id="acknowledgements"><div class="header-wrapper"><h2 id="a-acknowledgements"><bdi class="secno">A. </bdi>Acknowledgements</h2><a class="self-link" href="#acknowledgements" aria-label="Permalink for Appendix A."></a></div><p><em>This section is non-normative.</em></p>
+      
+
+      <p>
+The Working Group thanks the following individuals for significant
+contributions to the community: TBD
+      </p>
+
+      <p>
+Work on this specification has been supported by the Rebooting the
+Web of Trust community facilitated by Christopher Allen, Joe Andrieu, and
+Erica Connell. The participants in the Internet Identity Workshop,
+facilitated by Phil Windley, Kaliya Young, Doc Searls, and Heidi Nobantu Saul,
+also supported the refinement of this work through numerous working sessions
+designed to educate about, debate on, and improve this specification.
+      </p>
+
+      <p>
+The Working Group would like to thank the following individuals for reviewing
+and providing feedback on the specification (in alphabetical order):
+      </p>
+
+    </section>
+  
+
+<section id="references" class="appendix"><div class="header-wrapper"><h2 id="b-references"><bdi class="secno">B. </bdi>References</h2><a class="self-link" href="#references" aria-label="Permalink for Appendix B."></a></div><section id="normative-references"><div class="header-wrapper"><h3 id="b-1-normative-references"><bdi class="secno">B.1 </bdi>Normative references</h3><a class="self-link" href="#normative-references" aria-label="Permalink for Appendix B.1"></a></div>
+    
+    <dl class="bibliography"><dt id="bib-etsi-trust-lists">[ETSI-TRUST-LISTS]</dt><dd>
+      <a href="https://www.etsi.org/deliver/etsi_ts/119600_119699/119612/02.01.01_60/ts_119612v020101p.pdf"><cite>Electronic Signatures and Infrastructures (ESI); Trusted Lists</cite></a>. ETSI.  ETSI. ETSI Standard TS 119 612 V2.1.1 (2015-07). URL: <a href="https://www.etsi.org/deliver/etsi_ts/119600_119699/119612/02.01.01_60/ts_119612v020101p.pdf">https://www.etsi.org/deliver/etsi_ts/119600_119699/119612/02.01.01_60/ts_119612v020101p.pdf</a>
+    </dd><dt id="bib-infra">[infra]</dt><dd>
+      <a href="https://infra.spec.whatwg.org/"><cite>Infra Standard</cite></a>. Anne van Kesteren; Domenic Denicola.  WHATWG. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
+    </dd><dt id="bib-rfc2119">[RFC2119]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc2119">https://www.rfc-editor.org/rfc/rfc2119</a>
+    </dd><dt id="bib-rfc5280">[RFC5280]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc5280"><cite>Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile</cite></a>. D. Cooper; S. Santesson; S. Farrell; S. Boeyen; R. Housley; W. Polk.  IETF. May 2008. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc5280">https://www.rfc-editor.org/rfc/rfc5280</a>
+    </dd><dt id="bib-rfc8174">[RFC8174]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc8174"><cite>Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</cite></a>. B. Leiba.  IETF. May 2017. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc8174">https://www.rfc-editor.org/rfc/rfc8174</a>
+    </dd><dt id="bib-url">[url]</dt><dd>
+      <a href="https://url.spec.whatwg.org/"><cite>URL Standard</cite></a>. Anne van Kesteren.  WHATWG. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
+    </dd><dt id="bib-vc-data-model">[VC-DATA-MODEL]</dt><dd>
+      <a href="https://www.w3.org/TR/vc-data-model-2.0/"><cite>Verifiable Credentials Data Model v2.0</cite></a>. Ivan Herman; Michael Jones; Manu Sporny; Ted Thibodeau Jr; Gabe Cohen.  W3C. 15 May 2025. W3C Recommendation. URL: <a href="https://www.w3.org/TR/vc-data-model-2.0/">https://www.w3.org/TR/vc-data-model-2.0/</a>
+    </dd></dl>
+  </section></section><p role="navigation" id="back-to-top">
+    <a href="#title"><abbr title="Back to Top">↑</abbr></a>
+  </p><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-conforming-document" aria-label="Links in this document to definition: conforming document">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-conforming-document" aria-label="Permalink for definition: conforming document. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-conforming-document-1" title="§ 1.1 Conformance">§ 1.1 Conformance</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-conforming-processor" aria-label="Links in this document to definition: conforming processor">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-conforming-processor" aria-label="Permalink for definition: conforming processor. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+      <li>Not referenced in this document.</li>
+    </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-recognized-entity" aria-label="Links in this document to definition: recognized entity">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-recognized-entity" aria-label="Permalink for definition: recognized entity. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-recognized-entity-1" title="§ 2.2 RecognizedEntity">§ 2.2 RecognizedEntity</a> <a href="#ref-for-dfn-recognized-entity-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-recognized-entity-3" title="Reference 3">(3)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-recognized-entity-4" title="§ 2.3 RecognizedAction">§ 2.3 RecognizedAction</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-recognized-action" aria-label="Links in this document to definition: recognized action">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-recognized-action" aria-label="Permalink for definition: recognized action. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+      <li>Not referenced in this document.</li>
+    </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-recognition-credential" aria-label="Links in this document to definition: verifiable recognition credential">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-recognition-credential" aria-label="Permalink for definition: verifiable recognition credential. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-recognition-credential-1" title="§ 2.4 VerifiableRecognitionCredential">§ 2.4 VerifiableRecognitionCredential</a> <a href="#ref-for-dfn-recognition-credential-2" title="Reference 2">(2)</a> 
+    </li>
+  </ul>
+    </div><script id="respec-highlight-vars">(() => {
+// @ts-check
+
+if (document.respec) {
+  document.respec.ready.then(setupVarHighlighter);
+} else {
+  setupVarHighlighter();
+}
+
+function setupVarHighlighter() {
+  document
+    .querySelectorAll("var")
+    .forEach(varElem => varElem.addEventListener("click", highlightListener));
+}
+
+function highlightListener(ev) {
+  ev.stopPropagation();
+  const { target: varElem } = ev;
+  const hightligtedElems = highlightVars(varElem);
+  const resetListener = () => {
+    const hlColor = getHighlightColor(varElem);
+    hightligtedElems.forEach(el => removeHighlight(el, hlColor));
+    [...HL_COLORS.keys()].forEach(key => HL_COLORS.set(key, true));
+  };
+  if (hightligtedElems.length) {
+    document.body.addEventListener("click", resetListener, { once: true });
+  }
+}
+
+// availability of highlight colors. colors from var.css
+const HL_COLORS = new Map([
+  ["respec-hl-c1", true],
+  ["respec-hl-c2", true],
+  ["respec-hl-c3", true],
+  ["respec-hl-c4", true],
+  ["respec-hl-c5", true],
+  ["respec-hl-c6", true],
+  ["respec-hl-c7", true],
+]);
+
+function getHighlightColor(target) {
+  // return current colors if applicable
+  const { value } = target.classList;
+  const re = /respec-hl-\w+/;
+  const activeClass = re.test(value) && value.match(re);
+  if (activeClass) return activeClass[0];
+
+  // first color preference
+  if (HL_COLORS.get("respec-hl-c1") === true) return "respec-hl-c1";
+
+  // otherwise get some other available color
+  return [...HL_COLORS.keys()].find(c => HL_COLORS.get(c)) || "respec-hl-c1";
+}
+
+function highlightVars(varElem) {
+  const textContent = norm(varElem.textContent);
+  const parent = varElem.closest(".algorithm, section");
+  const highlightColor = getHighlightColor(varElem);
+
+  const varsToHighlight = [...parent.querySelectorAll("var")].filter(
+    el =>
+      norm(el.textContent) === textContent &&
+      el.closest(".algorithm, section") === parent
+  );
+
+  // update availability of highlight color
+  const colorStatus = varsToHighlight[0].classList.contains("respec-hl");
+  HL_COLORS.set(highlightColor, colorStatus);
+
+  // highlight vars
+  if (colorStatus) {
+    varsToHighlight.forEach(el => removeHighlight(el, highlightColor));
+    return [];
+  } else {
+    varsToHighlight.forEach(el => addHighlight(el, highlightColor));
+  }
+  return varsToHighlight;
+}
+
+function removeHighlight(el, highlightColor) {
+  el.classList.remove("respec-hl", highlightColor);
+  // clean up empty class attributes so they don't come in export
+  if (!el.classList.length) el.removeAttribute("class");
+}
+
+function addHighlight(elem, highlightColor) {
+  elem.classList.add("respec-hl", highlightColor);
+}
+
+/**
+ * Same as `norm` from src/core/utils, but our build process doesn't allow
+ * imports in runtime scripts, so duplicated here.
+ * @param {string} str
+ */
+function norm(str) {
+  return str.trim().replace(/\s+/g, " ");
+}
+})()</script><script id="respec-dfn-panel">(() => {
+// @ts-check
+if (document.respec) {
+  document.respec.ready.then(setupPanel);
+} else {
+  setupPanel();
+}
+
+function setupPanel() {
+  const listener = panelListener();
+  document.body.addEventListener("keydown", listener);
+  document.body.addEventListener("click", listener);
+}
+
+function panelListener() {
+  /** @type {HTMLElement} */
+  let panel = null;
+  return event => {
+    const { target, type } = event;
+
+    if (!(target instanceof HTMLElement)) return;
+
+    // For keys, we only care about Enter key to activate the panel
+    // otherwise it's activated via a click.
+    if (type === "keydown" && event.key !== "Enter") return;
+
+    const action = deriveAction(event);
+
+    switch (action) {
+      case "show": {
+        hidePanel(panel);
+        /** @type {HTMLElement} */
+        const dfn = target.closest("dfn, .index-term");
+        panel = document.getElementById(`dfn-panel-for-${dfn.id}`);
+        const coords = deriveCoordinates(event);
+        displayPanel(dfn, panel, coords);
+        break;
+      }
+      case "dock": {
+        panel.style.left = null;
+        panel.style.top = null;
+        panel.classList.add("docked");
+        break;
+      }
+      case "hide": {
+        hidePanel(panel);
+        panel = null;
+        break;
+      }
+    }
+  };
+}
+
+/**
+ * @param {MouseEvent|KeyboardEvent} event
+ */
+function deriveCoordinates(event) {
+  const target = /** @type HTMLElement */ (event.target);
+
+  // We prevent synthetic AT clicks from putting
+  // the dialog in a weird place. The AT events sometimes
+  // lack coordinates, so they have clientX/Y = 0
+  const rect = target.getBoundingClientRect();
+  if (
+    event instanceof MouseEvent &&
+    event.clientX >= rect.left &&
+    event.clientY >= rect.top
+  ) {
+    // The event probably happened inside the bounding rect...
+    return { x: event.clientX, y: event.clientY };
+  }
+
+  // Offset to the middle of the element
+  const x = rect.x + rect.width / 2;
+  // Placed at the bottom of the element
+  const y = rect.y + rect.height;
+  return { x, y };
+}
+
+/**
+ * @param {Event} event
+ */
+function deriveAction(event) {
+  const target = /** @type {HTMLElement} */ (event.target);
+  const hitALink = !!target.closest("a");
+  if (target.closest("dfn:not([data-cite]), .index-term")) {
+    return hitALink ? "none" : "show";
+  }
+  if (target.closest(".dfn-panel")) {
+    if (hitALink) {
+      return target.classList.contains("self-link") ? "hide" : "dock";
+    }
+    const panel = target.closest(".dfn-panel");
+    return panel.classList.contains("docked") ? "hide" : "none";
+  }
+  if (document.querySelector(".dfn-panel:not([hidden])")) {
+    return "hide";
+  }
+  return "none";
+}
+
+/**
+ * @param {HTMLElement} dfn
+ * @param {HTMLElement} panel
+ * @param {{ x: number, y: number }} clickPosition
+ */
+function displayPanel(dfn, panel, { x, y }) {
+  panel.hidden = false;
+  // distance (px) between edge of panel and the pointing triangle (caret)
+  const MARGIN = 20;
+
+  const dfnRects = dfn.getClientRects();
+  // Find the `top` offset when the `dfn` can be spread across multiple lines
+  let closestTop = 0;
+  let minDiff = Infinity;
+  for (const rect of dfnRects) {
+    const { top, bottom } = rect;
+    const diffFromClickY = Math.abs((top + bottom) / 2 - y);
+    if (diffFromClickY < minDiff) {
+      minDiff = diffFromClickY;
+      closestTop = top;
+    }
+  }
+
+  const top = window.scrollY + closestTop + dfnRects[0].height;
+  const left = x - MARGIN;
+  panel.style.left = `${left}px`;
+  panel.style.top = `${top}px`;
+
+  // Find if the panel is flowing out of the window
+  const panelRect = panel.getBoundingClientRect();
+  const SCREEN_WIDTH = Math.min(window.innerWidth, window.screen.width);
+  if (panelRect.right > SCREEN_WIDTH) {
+    const newLeft = Math.max(MARGIN, x + MARGIN - panelRect.width);
+    const newCaretOffset = left - newLeft;
+    panel.style.left = `${newLeft}px`;
+    /** @type {HTMLElement} */
+    const caret = panel.querySelector(".caret");
+    caret.style.left = `${newCaretOffset}px`;
+  }
+
+  // As it's a dialog, we trap focus.
+  // TODO: when <dialog> becomes a implemented, we should really
+  // use that.
+  trapFocus(panel, dfn);
+}
+
+/**
+ * @param {HTMLElement} panel
+ * @param {HTMLElement} dfn
+ * @returns
+ */
+function trapFocus(panel, dfn) {
+  /** @type NodeListOf<HTMLAnchorElement> elements */
+  const anchors = panel.querySelectorAll("a[href]");
+  // No need to trap focus
+  if (!anchors.length) return;
+
+  // Move focus to first anchor element
+  const first = anchors.item(0);
+  first.focus();
+
+  const trapListener = createTrapListener(anchors, panel, dfn);
+  panel.addEventListener("keydown", trapListener);
+
+  // Hiding the panel releases the trap
+  const mo = new MutationObserver(records => {
+    const [record] = records;
+    const target = /** @type HTMLElement */ (record.target);
+    if (target.hidden) {
+      panel.removeEventListener("keydown", trapListener);
+      mo.disconnect();
+    }
+  });
+  mo.observe(panel, { attributes: true, attributeFilter: ["hidden"] });
+}
+
+/**
+ *
+ * @param {NodeListOf<HTMLAnchorElement>} anchors
+ * @param {HTMLElement} panel
+ * @param {HTMLElement} dfn
+ * @returns
+ */
+function createTrapListener(anchors, panel, dfn) {
+  const lastIndex = anchors.length - 1;
+  let currentIndex = 0;
+  return event => {
+    switch (event.key) {
+      // Hitting "Tab" traps us in a nice loop around elements.
+      case "Tab": {
+        event.preventDefault();
+        currentIndex += event.shiftKey ? -1 : +1;
+        if (currentIndex < 0) {
+          currentIndex = lastIndex;
+        } else if (currentIndex > lastIndex) {
+          currentIndex = 0;
+        }
+        anchors.item(currentIndex).focus();
+        break;
+      }
+
+      // Hitting "Enter" on an anchor releases the trap.
+      case "Enter":
+        hidePanel(panel);
+        break;
+
+      // Hitting "Escape" returns focus to dfn.
+      case "Escape":
+        hidePanel(panel);
+        dfn.focus();
+        return;
+    }
+  };
+}
+
+/** @param {HTMLElement} panel */
+function hidePanel(panel) {
+  if (!panel) return;
+  panel.hidden = true;
+  panel.classList.remove("docked");
+}
+})()</script><script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script></body></html>


### PR DESCRIPTION
Needs review by W3C Staff: @iherman and/or @pchampin

Once published here, the CG report itself will also be added to
https://github.com/w3c/cg-reports/tree/main/credentials

NOTE: Needs date update once we know what the publication date will actually be.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-recognition/pull/57.html" title="Last updated on Mar 20, 2026, 4:06 PM UTC (11fb0b7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-recognition/57/f5ecb44...11fb0b7.html" title="Last updated on Mar 20, 2026, 4:06 PM UTC (11fb0b7)">Diff</a>