### PR TITLE
Rename the specification to be more accurate.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Verifiable Issuers and Verifiers v0.9</title>
+    <title>Verifiable Credentials for Recognition v0.9</title>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
     <!--
       === NOTA BENE ===
@@ -18,7 +18,7 @@
         specStatus: "CG-DRAFT",
 
         // the specification's short name, as in http://www.w3.org/TR/short-name/
-        shortName: "verifiable-iv",
+        shortName: "vc-recognition",
         group: "credentials",
 
         // if you wish the publication date to be other than today, set this
@@ -30,7 +30,7 @@
         // previousMaturity:  "WD",
 
         // if there a publicly available Editor's Draft, this is the link
-        edDraftURI: "https://github.com/w3c-ccg/verifiable-issuers-verifiers/",
+        edDraftURI: "https://github.com/w3c-ccg/vc-recognition/",
 
         // if this is a LCWD, uncomment and set the end of its review period
         // lcEnd: "2009-08-05",


### PR DESCRIPTION
This PR renames the specification to "Verifiable Credentials for Recognition" with a shortname of `vc-recognition`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/verifiable-issuers-verifiers/pull/58.html" title="Last updated on Mar 17, 2026, 3:21 PM UTC (3c79db1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/verifiable-issuers-verifiers/58/c5fbc2a...3c79db1.html" title="Last updated on Mar 17, 2026, 3:21 PM UTC (3c79db1)">Diff</a>