### PR TITLE
Set publication date to 2026-03-20.

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,8 @@
 
         // if there a publicly available Editor's Draft, this is the link
         edDraftURI: "https://github.com/w3c-ccg/vc-recognition/",
-        latestVersion: "https://www.w3.org/community/reports/credentials/CG-FINAL-vc-recognition-YYYYMMDD/",
+        latestVersion: "https://www.w3.org/community/reports/credentials/CG-FINAL-vc-recognition-20260320/",
+        publishDate: "2026-03-20",
 
         // if this is a LCWD, uncomment and set the end of its review period
         // lcEnd: "2009-08-05",

--- a/transitions/2026/CG-FINAL/index.html
+++ b/transitions/2026/CG-FINAL/index.html
@@ -171,7 +171,7 @@ credential they are using is recognized within a particular ecosystem. The
 specification is designed to interoperate with existing &quot;trust infrastructures&quot;,
 such as X.509 certificate authority lists and ETSI Trust Service Lists, while
 enabling new decentralized ecosystems to be built using verifiable credentials.">
-<link rel="canonical" href="https://www.w3.org/community/reports/credentials/CG-FINAL-vc-recognition-YYYYMMDD/">
+<link rel="canonical" href="https://www.w3.org/community/reports/credentials/CG-FINAL-vc-recognition-20260320/">
 <style>
 .hljs{--base:#fafafa;--mono-1:#383a42;--mono-2:#686b77;--mono-3:#717277;--hue-1:#0b76c5;--hue-2:#336ae3;--hue-3:#a626a4;--hue-4:#42803c;--hue-5:#ca4706;--hue-5-2:#c91243;--hue-6:#986801;--hue-6-2:#9a6a01}
 @media (prefers-color-scheme:dark){
@@ -219,7 +219,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   "shortName": "vc-recognition",
   "group": "credentials",
   "edDraftURI": "https://github.com/w3c-ccg/vc-recognition/",
-  "latestVersion": "https://www.w3.org/community/reports/credentials/CG-FINAL-vc-recognition-YYYYMMDD/",
+  "latestVersion": "https://www.w3.org/community/reports/credentials/CG-FINAL-vc-recognition-20260320/",
+  "publishDate": "2026-03-20",
   "editors": [
     {
       "name": "Isaac Henderson Johnson Jeyakumar v0.1,0.2",
@@ -311,7 +312,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <a class="u-url" href="https://www.w3.org/community/reports/credentials/CG-FINAL-vc-recognition-20260320/">https://www.w3.org/community/reports/credentials/CG-FINAL-vc-recognition-20260320/</a>
             </dd>
       <dt>Latest published version:</dt><dd>
-              <a href="https://www.w3.org/community/reports/credentials/CG-FINAL-vc-recognition-YYYYMMDD/">https://www.w3.org/community/reports/credentials/CG-FINAL-vc-recognition-YYYYMMDD/</a>
+              <a href="https://www.w3.org/community/reports/credentials/CG-FINAL-vc-recognition-20260320/">https://www.w3.org/community/reports/credentials/CG-FINAL-vc-recognition-20260320/</a>
             </dd>
       <dt>Latest editor's draft:</dt><dd><a href="https://github.com/w3c-ccg/vc-recognition/">https://github.com/w3c-ccg/vc-recognition/</a></dd>
       


### PR DESCRIPTION
Same situation as https://github.com/w3c-ccg/vcalm/pull/612


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-recognition/pull/59.html" title="Last updated on Mar 23, 2026, 2:52 PM UTC (ce3a8b2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-recognition/59/d552121...ce3a8b2.html" title="Last updated on Mar 23, 2026, 2:52 PM UTC (ce3a8b2)">Diff</a>