### PR TITLE
Add `digestSRI` property to General Properties

### DIFF
--- a/index.html
+++ b/index.html
@@ -432,6 +432,16 @@ of the [[[VC-DATA-MODEL]]] specification.
               </td>
             </tr>
             <tr>
+              <td>digestSRI</td>
+              <td>
+One or more cryptographic digests, as defined by the `hash-expression` ABNF
+grammar defined in the [[[SRI]]] specification, used to verify the integrity of
+resources associated with the entity. The values for this property are defined in
+<a data-cite="VC-DATA-MODEL#integrity-of-related-resources">Section 5.3: Integrity of Related Resources</a>
+of the [[[VC-DATA-MODEL]]] specification.
+              </td>
+            </tr>
+            <tr>
               <td>digestMultibase</td>
               <td>
 One or more cryptographic digests used to verify the integrity of resources

--- a/index.html
+++ b/index.html
@@ -426,19 +426,20 @@ Each value MUST be a [=URL=].
               <td>description</td>
               <td>
 A human-readable description providing details about the entity. The value for
-this property is defined in
-<a data-cite="VC-DATA-MODEL#names-and-descriptions">Section 4.6: Names and Descriptions</a>
-of the [[[VC-DATA-MODEL]]] specification.
+this property is defined in the
+<a data-cite="VC-DATA-MODEL#names-and-descriptions">Names and Descriptions</a>
+section of the [[[VC-DATA-MODEL]]] specification.
               </td>
             </tr>
             <tr>
               <td>digestSRI</td>
               <td>
 One or more cryptographic digests, as defined by the `hash-expression` ABNF
-grammar defined in the [[[SRI]]] specification, used to verify the integrity of
-resources associated with the entity. The values for this property are defined in
-<a data-cite="VC-DATA-MODEL#integrity-of-related-resources">Section 5.3: Integrity of Related Resources</a>
-of the [[[VC-DATA-MODEL]]] specification.
+grammar defined in the [[[SRI]]] specification, used to verify the integrity
+of resources associated with the entity. The values for this property are
+defined in the
+<a data-cite="VC-DATA-MODEL#integrity-of-related-resources">Integrity of
+Related Resources</a> section of the [[[VC-DATA-MODEL]]] specification.
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
Closes #68.

## Summary

Adds the `digestSRI` property to the General Properties table, aligning with [VCDM 2.1 Section 5.3: Integrity of Related Resources](https://www.w3.org/TR/vc-data-model-2.1/#integrity-of-related-resources), which defines both `digestSRI` and `digestMultibase` as mechanisms for integrity verification of related resources.

## Changes

- **General Properties table**: Added a `digestSRI` row describing the property, with a reference to the SRI specification and VCDM Section 5.3.

## Rationale

The current specification only references `digestMultibase` for integrity verification, but VCDM Section 5.3 defines both `digestSRI` and `digestMultibase`. The `digestSRI` property uses the [Subresource Integrity](https://www.w3.org/TR/SRI/) format, which is a W3C Recommendation with native browser support.

## Note
I haven't updated an example using `digestMultibase`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shigeya/vc-recognition/pull/69.html" title="Last updated on Apr 28, 2026, 4:53 PM UTC (6f1769a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-recognition/69/99c7159...shigeya:6f1769a.html" title="Last updated on Apr 28, 2026, 4:53 PM UTC (6f1769a)">Diff</a>