### PR TITLE
Adjust URL of live version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ enabling new decentralized ecosystems to be built using verifiable credentials.
 
 You can view the live version of this specification here:
 
-https://w3c-ccg.github.io/vc-recognition/
+https://w3c.github.io/vc-recognized-entities/
 
 
 While we prefer the creation of issues and Pull Requests in the GitHub


### PR DESCRIPTION
The README links to the previous previous repository and name. The repository got moved to the W3C organization and has just been renamed.

(Side note: GitHub only redirects repositories but not GitHub Pages. https://github.com/w3c/w3c.github.io/pull/153 should add an HTML-based redirect from the former name to the new one)