### PR TITLE
Handled a link checker issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -549,11 +549,11 @@ A [=URL=], or object containing properties from Section
               <td>outputValidation</td>
               <td>
 The value of the `outputValidation`
-<a data-cite="VC-DATA-MODEL#property">property</a> MUST be one or more data
+property MUST be one or more data
 schemas that provide [=verifiers=] with enough information to determine whether
 the provided data conforms to the provided schema(s). Each validator MUST
 specify its `type` (for example, `JsonSchema`) and an `id`
-<a data-cite="VC-DATA-MODEL#property">property</a> that MUST be a [=URL=]
+property that MUST be a [=URL=]
 identifying the schema file. The specific type definition determines the precise
 contents of each data schema. If multiple schemas are present, validity is
 determined according to the processing rules outlined by each associated `type`

--- a/transitions/2026/FPWD/index.html
+++ b/transitions/2026/FPWD/index.html
@@ -43,11 +43,11 @@ dfn{cursor:pointer}
 .dfn-panel li{margin-left:1em}
 .dfn-panel.docked{position:fixed;left:.5em;top:unset;bottom:2em;margin:0 auto;max-width:calc(100vw - .75em * 2 - .5em - .2em * 2);max-height:30vh;overflow:auto}
 </style>
-    
+
 <title>Recognized Entities v1.0</title>
-    
-    
-    
+
+
+
 <style id="respec-mainstyle">
 @keyframes pop{
 0%{transform:scale(1,1)}
@@ -98,8 +98,8 @@ dd{margin-left:0}
 body:has(input[name=color-scheme][value=light]:checked),head:not(:has(meta[name=color-scheme][content~=dark]))+body{color-scheme:light}
 body:has(input[name=color-scheme][value=dark]:checked){color-scheme:dark}
 </style>
-    
-    
+
+
 <style>
 
 code {
@@ -178,9 +178,9 @@ table.simple tbody tr:nth-of-type(even) {
 table.simple tbody tr:last-of-type {
     border-bottom: 2px solid #005a9c;
 }
-    
+
 </style>
-  
+
 <meta name="color-scheme" content="light">
 <meta name="description" content="This specification describes a data model with which one or more recognized
 entities, such as one or more persons and/or organizations, can be described as
@@ -367,17 +367,17 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
                   </dd><dd>
                     <a href="https://github.com/w3c/vc-recognized-entities/commits/">Commit history</a>
                   </dd>
-        
-        
-        
-        
-        
+
+
+
+
+
         <dt>
                 Editor:
               </dt><dd class="editor p-author h-card vcard" data-editor-id="41758">
     <span class="p-name fn">Manu Sporny</span> (<span class="p-org org h-org">Digital Bazaar</span>)
   </dd>
-        
+
         <dt>
                 Authors:
               </dt><dd class="editor p-author h-card vcard">
@@ -403,19 +403,19 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
         <a href="https://github.com/w3c/vc-recognized-entities/issues/new/choose">new issue</a>,
         <a href="https://github.com/w3c/vc-recognized-entities/issues/">open issues</a>)
       </dd>
-        
+
         <dt>Meetings:</dt><dd>
     <a href="https://www.w3.org/events/meetings/07bee2e8-d70d-4471-acf9-b730a2988a19/#next">View next scheduled meeting</a>
   </dd>
       </dl>
     </details>
-    
-    
+
+
     <p class="copyright">
     <a href="https://www.w3.org/policies/#copyright">Copyright</a>
     ©
     2026
-    
+
     <a href="https://www.w3.org/">World Wide Web Consortium</a>.
     <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
     <a href="https://www.w3.org/policies/#Legal_Disclaimer">liability</a>,
@@ -453,22 +453,22 @@ not fit for production deployment.
     This document was published by the <a href="https://www.w3.org/groups/wg/vc">Verifiable Credentials Working Group</a> as
     a First Public Working Draft using the
         <a href="https://www.w3.org/policies/process/20250818/#recs-and-notes">Recommendation
-          track</a>. 
+          track</a>.
   </p><p>Publication as
   a First Public Working Draft does not imply endorsement
   by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members. </p><p>
     This is a draft document and may be updated, replaced, or obsoleted by other
     documents at any time. It is inappropriate to cite this document as other
     than a work in progress.
-    
+
   </p><p>
-    
+
         This document was produced by a group
         operating under the
         <a href="https://www.w3.org/policies/patent-policy/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent
           Policy</a>.
-      
-    
+
+
                 <abbr title="World Wide Web Consortium">W3C</abbr> maintains a
                 <a rel="disclosure" href="https://www.w3.org/groups/wg/vc/ipr">public list of any patent disclosures</a>
           made in connection with the deliverables of
@@ -478,14 +478,14 @@ not fit for production deployment.
           <a href="https://www.w3.org/policies/patent-policy/#def-essential">Essential Claim(s)</a>
           must disclose the information in accordance with
           <a href="https://www.w3.org/policies/patent-policy/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
-        
+
   </p><p>
                       This document is governed by the
                       <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20250818/">18 August 2025 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
                     </p></section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a class="tocxref" href="#abstract">Abstract</a></li><li class="tocline"><a class="tocxref" href="#sotd">Status of This Document</a></li><li class="tocline"><a class="tocxref" href="#introduction"><bdi class="secno">1. </bdi>Introduction</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#conformance"><bdi class="secno">1.1 </bdi>Conformance</a></li></ol></li><li class="tocline"><a class="tocxref" href="#data-model"><bdi class="secno">2. </bdi>Data Model</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#general-properties"><bdi class="secno">2.1 </bdi>General Properties</a></li><li class="tocline"><a class="tocxref" href="#recognizedentity"><bdi class="secno">2.2 </bdi>RecognizedEntity</a></li><li class="tocline"><a class="tocxref" href="#recognizedaction"><bdi class="secno">2.3 </bdi>RecognizedAction</a></li><li class="tocline"><a class="tocxref" href="#verifiablerecognitioncredential"><bdi class="secno">2.4 </bdi>VerifiableRecognitionCredential</a></li></ol></li><li class="tocline"><a class="tocxref" href="#privacy-considerations"><bdi class="secno">3. </bdi>Privacy Considerations</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#surveillance-of-individuals-as-recognized-entities"><bdi class="secno">3.1 </bdi>Surveillance of Individuals as Recognized Entities</a></li><li class="tocline"><a class="tocxref" href="#holder-provided-recognition-credentials"><bdi class="secno">3.2 </bdi>Holder-Provided Recognition Credentials</a></li><li class="tocline"><a class="tocxref" href="#harms-by-association"><bdi class="secno">3.3 </bdi>Harms by Association</a></li></ol></li><li class="tocline"><a class="tocxref" href="#security-considerations"><bdi class="secno">4. </bdi>Security Considerations</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#validate-before-sharing"><bdi class="secno">4.1 </bdi>Validate Before Sharing</a></li><li class="tocline"><a class="tocxref" href="#issuer-impersonation"><bdi class="secno">4.2 </bdi>Issuer Impersonation</a></li><li class="tocline"><a class="tocxref" href="#selecting-appropriate-validity-periods"><bdi class="secno">4.3 </bdi>Selecting Appropriate Validity Periods</a></li><li class="tocline"><a class="tocxref" href="#external-resource-tampering"><bdi class="secno">4.4 </bdi>External Resource Tampering</a></li><li class="tocline"><a class="tocxref" href="#verifying-recognition-chains"><bdi class="secno">4.5 </bdi>Verifying Recognition Chains</a></li><li class="tocline"><a class="tocxref" href="#abuse-of-recognized-actions"><bdi class="secno">4.6 </bdi>Abuse of Recognized Actions</a></li></ol></li><li class="tocline"><a class="tocxref" href="#relationship-to-other-technologies"><bdi class="secno">A. </bdi>Relationship to Other Technologies</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#etsi-trust-service-lists"><bdi class="secno">A.1 </bdi>ETSI Trust Service Lists</a></li><li class="tocline"><a class="tocxref" href="#x-509-certificate-authority-lists"><bdi class="secno">A.2 </bdi>X.509 Certificate Authority Lists</a></li><li class="tocline"><a class="tocxref" href="#iso-iec-18013-5-mdl-vical"><bdi class="secno">A.3 </bdi>ISO/IEC 18013-5 mDL VICAL</a></li></ol></li><li class="tocline"><a class="tocxref" href="#acknowledgements"><bdi class="secno">B. </bdi>Acknowledgements</a></li><li class="tocline"><a class="tocxref" href="#references"><bdi class="secno">C. </bdi>References</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><bdi class="secno">C.1 </bdi>Normative references</a></li></ol></li></ol></nav>
 
     <section id="introduction"><div class="header-wrapper"><h2 id="x1-introduction"><bdi class="secno">1. </bdi>Introduction</h2><a class="self-link" href="#introduction" aria-label="Permalink for Section 1."></a></div>
-      
+
 
       <p>
 The <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-credential">verifiable credential</a> ecosystem relies on the ability of <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier">verifiers</a>
@@ -573,7 +573,7 @@ JSON-LD.
     </section>
 
     <section id="data-model"><div class="header-wrapper"><h2 id="x2-data-model"><bdi class="secno">2. </bdi>Data Model</h2><a class="self-link" href="#data-model" aria-label="Permalink for Section 2."></a></div>
-      
+
 
       <p>
 The following sections outline the data model that is used by this specification
@@ -596,7 +596,7 @@ details of the list operator description.
 </p>
 
     <section id="general-properties"><div class="header-wrapper"><h3 id="x2-1-general-properties"><bdi class="secno">2.1 </bdi>General Properties</h3><a class="self-link" href="#general-properties" aria-label="Permalink for Section 2.1"></a></div>
-        
+
 
         <p>
 The properties in this section can be added to objects found in a
@@ -694,7 +694,7 @@ of the <cite><a data-matched-text="[[[VC-DATA-MODEL]]]" href="https://www.w3.org
     </section>
 
     <section id="recognizedentity"><div class="header-wrapper"><h3 id="x2-2-recognizedentity"><bdi class="secno">2.2 </bdi>RecognizedEntity</h3><a class="self-link" href="#recognizedentity" aria-label="Permalink for Section 2.2"></a></div>
-        
+
 
         <p>
 A <dfn id="dfn-recognized-entity" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">recognized entity</dfn> is any entity that is recognized by an <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers">issuer</a>
@@ -767,7 +767,7 @@ to this specification.
     </section>
 
     <section id="recognizedaction"><div class="header-wrapper"><h3 id="x2-3-recognizedaction"><bdi class="secno">2.3 </bdi>RecognizedAction</h3><a class="self-link" href="#recognizedaction" aria-label="Permalink for Section 2.3"></a></div>
-        
+
 
         <p>
 A <dfn id="dfn-recognized-action" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">recognized action</dfn> is an action that a <a data-link-type="dfn|abstract-op" href="#dfn-recognized-entity" class="internalDFN" id="ref-for-dfn-recognized-entity-4">recognized entity</a> is
@@ -806,11 +806,11 @@ A <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a
               <td>outputValidation</td>
               <td>
 The value of the <code>outputValidation</code>
-<a href="https://www.w3.org/TR/vc-data-model-2.0/#property">property</a> <em class="rfc2119">MUST</em> be one or more data
+property <em class="rfc2119">MUST</em> be one or more data
 schemas that provide <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier">verifiers</a> with enough information to determine whether
 the provided data conforms to the provided schema(s). Each validator <em class="rfc2119">MUST</em>
 specify its <code>type</code> (for example, <code>JsonSchema</code>) and an <code>id</code>
-<a href="https://www.w3.org/TR/vc-data-model-2.0/#property">property</a> that <em class="rfc2119">MUST</em> be a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>
+property that <em class="rfc2119">MUST</em> be a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>
 identifying the schema file. The specific type definition determines the precise
 contents of each data schema. If multiple schemas are present, validity is
 determined according to the processing rules outlined by each associated <code>type</code>
@@ -822,7 +822,7 @@ property.
     </section>
 
     <section id="verifiablerecognitioncredential"><div class="header-wrapper"><h3 id="x2-4-verifiablerecognitioncredential"><bdi class="secno">2.4 </bdi>VerifiableRecognitionCredential</h3><a class="self-link" href="#verifiablerecognitioncredential" aria-label="Permalink for Section 2.4"></a></div>
-        
+
 
         <p>
 When a <dfn data-lt="recognition credential|verifiable recognition credential" id="dfn-recognition-credential" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">verifiable recognition credential</dfn>
@@ -1076,7 +1076,7 @@ publishes an European Union ETSI Trust Services list [<cite><a class="bibref" da
     </section>
 
     <section id="privacy-considerations"><div class="header-wrapper"><h2 id="x3-privacy-considerations"><bdi class="secno">3. </bdi>Privacy Considerations</h2><a class="self-link" href="#privacy-considerations" aria-label="Permalink for Section 3."></a></div>
-      
+
 
       <p>
 This section details the general privacy considerations and specific privacy
@@ -1094,7 +1094,7 @@ provided by this specification.
       </p>
 
       <section id="surveillance-of-individuals-as-recognized-entities"><div class="header-wrapper"><h3 id="x3-1-surveillance-of-individuals-as-recognized-entities"><bdi class="secno">3.1 </bdi>Surveillance of Individuals as Recognized Entities</h3><a class="self-link" href="#surveillance-of-individuals-as-recognized-entities" aria-label="Permalink for Section 3.1"></a></div>
-        
+
         <div class="issue" id="issue-container-number-1"><div class="issue-title marker" id="h-issue"><span>Issue 1</span></div><p class="">
 A <code>VerifiableRecognitionCredential</code> publicly lists named organizations and
 people with their identifiers, legal names, URLs, and images. Aggregating
@@ -1110,7 +1110,7 @@ it requires honest actors.
       </section>
 
       <section id="holder-provided-recognition-credentials"><div class="header-wrapper"><h3 id="x3-2-holder-provided-recognition-credentials"><bdi class="secno">3.2 </bdi>Holder-Provided Recognition Credentials</h3><a class="self-link" href="#holder-provided-recognition-credentials" aria-label="Permalink for Section 3.2"></a></div>
-        
+
         <div class="issue" id="issue-container-number-2"><div class="issue-title marker" id="h-issue-0"><span>Issue 2</span></div><p class="">
 Having holders provide recognition credentials preserves privacy better than having
 the verifier reach out to the issuer to retrieve the recognition credential.
@@ -1118,7 +1118,7 @@ the verifier reach out to the issuer to retrieve the recognition credential.
       </section>
 
       <section id="harms-by-association"><div class="header-wrapper"><h3 id="x3-3-harms-by-association"><bdi class="secno">3.3 </bdi>Harms by Association</h3><a class="self-link" href="#harms-by-association" aria-label="Permalink for Section 3.3"></a></div>
-        
+
         <div class="issue" id="issue-container-number-3"><div class="issue-title marker" id="h-issue-1"><span>Issue 3</span></div><p class="">
 A <code>VerifiableRecognitionCredential</code> can reveal the membership structure of a
 private or sensitive ecosystem, such as healthcare credential issuers or
@@ -1137,7 +1137,7 @@ individuals (harm by association) -- unintended or not.
     </section>
 
     <section id="security-considerations"><div class="header-wrapper"><h2 id="x4-security-considerations"><bdi class="secno">4. </bdi>Security Considerations</h2><a class="self-link" href="#security-considerations" aria-label="Permalink for Section 4."></a></div>
-      
+
 
       <p>
 There are a number of security considerations that implementers should be
@@ -1162,7 +1162,7 @@ critical systems using the technology outlined in this specification.
       </p>
 
       <section id="validate-before-sharing"><div class="header-wrapper"><h3 id="x4-1-validate-before-sharing"><bdi class="secno">4.1 </bdi>Validate Before Sharing</h3><a class="self-link" href="#validate-before-sharing" aria-label="Permalink for Section 4.1"></a></div>
-        
+
         <p>
 When a <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-holders">holder</a> receives a <code>VerifiableRecognitionCredential</code> and shares it
 with others, there is a risk that the credential has not been properly vetted.
@@ -1192,7 +1192,7 @@ credential once trust has been established on the issuing entity.
       </section>
 
       <section id="issuer-impersonation"><div class="header-wrapper"><h3 id="x4-2-issuer-impersonation"><bdi class="secno">4.2 </bdi>Issuer Impersonation</h3><a class="self-link" href="#issuer-impersonation" aria-label="Permalink for Section 4.2"></a></div>
-        
+
         <div class="issue" id="issue-container-number-4"><div class="issue-title marker" id="h-issue-2"><span>Issue 4</span></div><p class="">
 A malicious actor could create a <code>VerifiableRecognitionCredential</code> that mimics a
 well-known recognizing authority by using a similar <code>issuer</code> identifier or name.
@@ -1213,7 +1213,7 @@ information together to help individuals not fall for scams.
       </section>
 
       <section id="selecting-appropriate-validity-periods"><div class="header-wrapper"><h3 id="x4-3-selecting-appropriate-validity-periods"><bdi class="secno">4.3 </bdi>Selecting Appropriate Validity Periods</h3><a class="self-link" href="#selecting-appropriate-validity-periods" aria-label="Permalink for Section 4.3"></a></div>
-        
+
         <div class="issue" id="issue-container-number-5"><div class="issue-title marker" id="h-issue-3"><span>Issue 5</span></div><p class="">
 Recognition credentials with excessively long <code>validUntil</code> periods may remain in
 circulation long after a recognized entity has been suspended, revoked, or
@@ -1231,7 +1231,7 @@ longer period -- why go longer than 24-48 hours?
       </section>
 
       <section id="external-resource-tampering"><div class="header-wrapper"><h3 id="x4-4-external-resource-tampering"><bdi class="secno">4.4 </bdi>External Resource Tampering</h3><a class="self-link" href="#external-resource-tampering" aria-label="Permalink for Section 4.4"></a></div>
-        
+
         <div class="issue" id="issue-container-number-6"><div class="issue-title marker" id="h-issue-4"><span>Issue 6</span></div><p class="">
 The <code>outputValidation</code> property references external schema files via URL. If
 those URLs are not protected by <code>digestMultibase</code> or other integrity checks, an
@@ -1244,7 +1244,7 @@ resources.
       </section>
 
       <section id="verifying-recognition-chains"><div class="header-wrapper"><h3 id="x4-5-verifying-recognition-chains"><bdi class="secno">4.5 </bdi>Verifying Recognition Chains</h3><a class="self-link" href="#verifying-recognition-chains" aria-label="Permalink for Section 4.5"></a></div>
-        
+
         <div class="issue" id="issue-container-number-7"><div class="issue-title marker" id="h-issue-5"><span>Issue 7</span></div><p class="">
 The <code>recognizedIn</code> property allows recognition credentials to chain to other
 registries such as ETSI Trust Service Lists, X.509 certificate authority lists,
@@ -1257,7 +1257,7 @@ structures and the risks of unbounded transitive trust.
       </section>
 
       <section id="abuse-of-recognized-actions"><div class="header-wrapper"><h3 id="x4-6-abuse-of-recognized-actions"><bdi class="secno">4.6 </bdi>Abuse of Recognized Actions</h3><a class="self-link" href="#abuse-of-recognized-actions" aria-label="Permalink for Section 4.6"></a></div>
-        
+
         <div class="issue" id="issue-container-number-8"><div class="issue-title marker" id="h-issue-6"><span>Issue 8</span></div><p class="">
 The <code>action</code> property is a free-form string (e.g., <code>issue</code>, <code>verify</code>). Without
 strict governance of allowable action values within an ecosystem, recognized
@@ -1272,7 +1272,7 @@ handle unrecognized action values.
     </section>
 
     <section class="appendix informative" id="relationship-to-other-technologies"><div class="header-wrapper"><h2 id="a-relationship-to-other-technologies"><bdi class="secno">A. </bdi>Relationship to Other Technologies</h2><a class="self-link" href="#relationship-to-other-technologies" aria-label="Permalink for Appendix A."></a></div><p><em>This section is non-normative.</em></p>
-      
+
 
       <p>
 This specification was designed with awareness of existing "trust
@@ -1283,7 +1283,7 @@ found in these technologies and is designed to interoperate with them via the
       </p>
 
       <section class="informative" id="etsi-trust-service-lists"><div class="header-wrapper"><h3 id="a-1-etsi-trust-service-lists"><bdi class="secno">A.1 </bdi>ETSI Trust Service Lists</h3><a class="self-link" href="#etsi-trust-service-lists" aria-label="Permalink for Appendix A.1"></a></div><p><em>This section is non-normative.</em></p>
-        
+
 
         <p>
 The European Telecommunications Standards Institute (ETSI) defines a format
@@ -1334,7 +1334,7 @@ for verifiers to contact a central registry during each interaction.
       </section>
 
       <section class="informative" id="x-509-certificate-authority-lists"><div class="header-wrapper"><h3 id="a-2-x-509-certificate-authority-lists"><bdi class="secno">A.2 </bdi>X.509 Certificate Authority Lists</h3><a class="self-link" href="#x-509-certificate-authority-lists" aria-label="Permalink for Appendix A.2"></a></div><p><em>This section is non-normative.</em></p>
-        
+
 
         <p>
 X.509 [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc5280" title="Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile">RFC5280</a></cite>] is a standard for public key infrastructure (PKI) that
@@ -1386,7 +1386,7 @@ ecosystem without requiring approval from a central gatekeeper.
       </section>
 
       <section class="informative" id="iso-iec-18013-5-mdl-vical"><div class="header-wrapper"><h3 id="a-3-iso-iec-18013-5-mdl-vical"><bdi class="secno">A.3 </bdi>ISO/IEC 18013-5 mDL VICAL</h3><a class="self-link" href="#iso-iec-18013-5-mdl-vical" aria-label="Permalink for Appendix A.3"></a></div><p><em>This section is non-normative.</em></p>
-        
+
 
         <p>
 ISO/IEC 18013-5 defines the mobile Driving License (mDL), a standard for
@@ -1439,7 +1439,7 @@ more open and composable trust ecosystems.
     </section>
 
     <section class="appendix informative" id="acknowledgements"><div class="header-wrapper"><h2 id="b-acknowledgements"><bdi class="secno">B. </bdi>Acknowledgements</h2><a class="self-link" href="#acknowledgements" aria-label="Permalink for Appendix B."></a></div><p><em>This section is non-normative.</em></p>
-      
+
 
       <p>
 The Working Group thanks the following individuals for significant
@@ -1461,10 +1461,10 @@ and providing feedback on the specification (in alphabetical order):
       </p>
 
     </section>
-  
+
 
 <section id="references" class="appendix"><div class="header-wrapper"><h2 id="c-references"><bdi class="secno">C. </bdi>References</h2><a class="self-link" href="#references" aria-label="Permalink for Appendix C."></a></div><section id="normative-references"><div class="header-wrapper"><h3 id="c-1-normative-references"><bdi class="secno">C.1 </bdi>Normative references</h3><a class="self-link" href="#normative-references" aria-label="Permalink for Appendix C.1"></a></div>
-    
+
     <dl class="bibliography"><dt id="bib-etsi-trust-lists">[ETSI-TRUST-LISTS]</dt><dd>
       <a href="https://www.etsi.org/deliver/etsi_ts/119600_119699/119612/02.01.01_60/ts_119612v020101p.pdf"><cite>Electronic Signatures and Infrastructures (ESI); Trusted Lists</cite></a>. ETSI.  ETSI. ETSI Standard TS 119 612 V2.1.1 (2015-07). URL: <a href="https://www.etsi.org/deliver/etsi_ts/119600_119699/119612/02.01.01_60/ts_119612v020101p.pdf">https://www.etsi.org/deliver/etsi_ts/119600_119699/119612/02.01.01_60/ts_119612v020101p.pdf</a>
     </dd><dt id="bib-infra">[infra]</dt><dd>
@@ -1486,21 +1486,21 @@ and providing feedback on the specification (in alphabetical order):
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-conforming-document" aria-label="Permalink for definition: conforming document. Activate to close this dialog.">Permalink</a>
-         
-        
+
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-conforming-document-1" title="§ 1.1 Conformance">§ 1.1 Conformance</a> 
+      <a href="#ref-for-dfn-conforming-document-1" title="§ 1.1 Conformance">§ 1.1 Conformance</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-conforming-processor" aria-label="Links in this document to definition: conforming processor">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-conforming-processor" aria-label="Permalink for definition: conforming processor. Activate to close this dialog.">Permalink</a>
-         
-        
+
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
@@ -1510,41 +1510,41 @@ and providing feedback on the specification (in alphabetical order):
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-recognized-entity" aria-label="Permalink for definition: recognized entity. Activate to close this dialog.">Permalink</a>
-         
-        
+
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-recognized-entity-1" title="§ 2.2 RecognizedEntity">§ 2.2 RecognizedEntity</a> <a href="#ref-for-dfn-recognized-entity-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-recognized-entity-3" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-recognized-entity-1" title="§ 2.2 RecognizedEntity">§ 2.2 RecognizedEntity</a> <a href="#ref-for-dfn-recognized-entity-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-recognized-entity-3" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-recognized-entity-4" title="§ 2.3 RecognizedAction">§ 2.3 RecognizedAction</a> 
+      <a href="#ref-for-dfn-recognized-entity-4" title="§ 2.3 RecognizedAction">§ 2.3 RecognizedAction</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-recognized-action" aria-label="Links in this document to definition: recognized action">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-recognized-action" aria-label="Permalink for definition: recognized action. Activate to close this dialog.">Permalink</a>
-         
-        
+
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-recognized-action-1" title="§ 4.1 Validate Before Sharing">§ 4.1 Validate Before Sharing</a> 
+      <a href="#ref-for-dfn-recognized-action-1" title="§ 4.1 Validate Before Sharing">§ 4.1 Validate Before Sharing</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-recognition-credential" aria-label="Links in this document to definition: verifiable recognition credential">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-recognition-credential" aria-label="Permalink for definition: verifiable recognition credential. Activate to close this dialog.">Permalink</a>
-         
-        
+
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-recognition-credential-1" title="§ 2.4 VerifiableRecognitionCredential">§ 2.4 VerifiableRecognitionCredential</a> <a href="#ref-for-dfn-recognition-credential-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-recognition-credential-1" title="§ 2.4 VerifiableRecognitionCredential">§ 2.4 VerifiableRecognitionCredential</a> <a href="#ref-for-dfn-recognition-credential-2" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><script id="respec-highlight-vars">(() => {


### PR DESCRIPTION
The W3C Link checker reported a fragment error on the `#property` fragment id in the VCDM 2.0 spec. I checked and, indeed, there is no such fragment id in the spec.

As a, possibly temporary, measure I removed the reference from this spec; it does not seem to be necessary. With this, the road is clear for the FPWD publication, and this link can be replaces later if needed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-recognized-entities/pull/76.html" title="Last updated on May 4, 2026, 5:54 AM UTC (9ce2f78)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-recognized-entities/76/319ac3d...9ce2f78.html" title="Last updated on May 4, 2026, 5:54 AM UTC (9ce2f78)">Diff</a>