### PR TITLE
Add support for arbitrary external entity registry lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -675,7 +675,7 @@ known to perform. The `id` value of the object MUST be a
 [=URL=]. The `type` value of the object MUST conform to the
 <a data-cite="VC-DATA-MODEL#types">type value space </a> defined in
 the [[[VC-DATA-MODEL]]] specification and SHOULD be `EtsiTrustServiceList`,
-`x509CertificateAuthorityList`, or `RecognizedEntityCredential`.
+`x509CertificateAuthorityList`, `ExternalEntityList`, or `RecognizedEntityCredential`.
               </td>
             </tr>
           </tbody>
@@ -687,11 +687,14 @@ addition to the properties above.
         </p>
 
         <p>
-A `recognizedIn` with a `type` property of `EtsiTrustServiceList` MUST conform
-to the [[[ETSI-TRUST-LISTS]]] specification. A list with `type` property of
+A `recognizedIn` entry with a `type` property value of `EtsiTrustServiceList` MUST conform
+to the [[[ETSI-TRUST-LISTS]]] specification. A list with a `type` property value of
 `x509CertificateAuthorityList` MUST conform to the [[[RFC5280]]] specification.
-A list with a `type` property of `RecognizedEntityCredential` MUST conform
-to this specification.
+A list with a `type` property value of `ExternalEntityList` SHOULD conform to a valid
+entity registry specification. The origin of the list URL referenced by the
+`id` property in this case establishes the root of trust for the list.
+A list with a `type` property value of `RecognizedEntityCredential` MUST conform
+to [[[VC-RECOGNIZED-ENTITIES]]].
         </p>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -989,7 +989,7 @@ for a particular type of [=verifiable credential=].
 
       <p>
 The final example below is used to publish information about an entity that
-publishes an European Union ETSI Trust Service List [[ETSI-TRUST-LISTS]]
+publishes a European Union ETSI Trust Service List [[ETSI-TRUST-LISTS]]
 using the generic `ExternalEntityList` type.
       </p>
 

--- a/index.html
+++ b/index.html
@@ -691,7 +691,7 @@ A `recognizedIn` entry with a `type` property value of `ExternalEntityList` SHOU
 to a valid entity list specification. The origin of the list URL referenced by the
 `id` property in this case establishes the root of trust for the list.
 Examples of this are the X.509 Certificate Authority List, as specified in [[[RFC5280]]]
-and the Electronic Signatures and Infrastructures (ESI) Trusted Lists, as specified in [[[ETSI-TRUST-LISTS]]].
+and the European Union ETSI Trust Service List, as specified in [[[ETSI-TRUST-LISTS]]].
 For the `ExternalEntityList` type, [=verifiers=] and [=credential=] consumers need to fetch the
 entity list resource referenced by the `id` property in order to determine the entity list specification
 that the resource complies with, determine if it supports that specification, and process/terminate accordingly.
@@ -989,7 +989,8 @@ for a particular type of [=verifiable credential=].
 
       <p>
 The final example below is used to publish information about an entity that
-publishes an European Union ETSI Trust Services list [[ETSI-TRUST-LISTS]].
+publishes an European Union ETSI Trust Service List [[ETSI-TRUST-LISTS]]
+using the generic `ExternalEntityList` type.
       </p>
 
       <pre class="example" title="An entity that publishes information conforming to an EU ETSI Trust Service list">

--- a/index.html
+++ b/index.html
@@ -673,9 +673,9 @@ An object that contains a reference to a document of recognized entities that
 contains this particular [=recognized entity=] as well as the actions it is
 known to perform. The `id` value of the object MUST be a
 [=URL=]. The `type` value of the object MUST conform to the
-<a data-cite="VC-DATA-MODEL#types">type value space </a> defined in
-the [[[VC-DATA-MODEL]]] specification and SHOULD be `EtsiTrustServiceList`,
-`x509CertificateAuthorityList`, `ExternalEntityList`, or `RecognizedEntityCredential`.
+<a data-cite="VC-DATA-MODEL#types">type value space</a> defined in
+the [[[VC-DATA-MODEL]]] specification and SHOULD be `ExternalEntityList`
+or `RecognizedEntityCredential`.
               </td>
             </tr>
           </tbody>
@@ -687,12 +687,14 @@ addition to the properties above.
         </p>
 
         <p>
-A `recognizedIn` entry with a `type` property value of `EtsiTrustServiceList` MUST conform
-to the [[[ETSI-TRUST-LISTS]]] specification. A list with a `type` property value of
-`x509CertificateAuthorityList` MUST conform to the [[[RFC5280]]] specification.
-A list with a `type` property value of `ExternalEntityList` SHOULD conform to a valid
-entity registry specification. The origin of the list URL referenced by the
+A `recognizedIn` entry with a `type` property value of `ExternalEntityList` SHOULD conform
+to a valid entity list specification. The origin of the list URL referenced by the
 `id` property in this case establishes the root of trust for the list.
+Examples of this are the X.509 Certificate Authority List, as specified in [[[RFC5280]]]
+and the Electronic Signatures and Infrastructures (ESI) Trusted Lists, as specified in [[[ETSI-TRUST-LISTS]]].
+For the `ExternalEntityList` type, [=verifiers=] and [=credential=] consumers need to fetch the
+entity list resource referenced by the `id` property in order to determine the entity list specification
+that the resource complies with, determine if it supports that specification, and process/terminate accordingly.
 A list with a `type` property value of `RecognizedEntityCredential` MUST conform
 to [[[VC-RECOGNIZED-ENTITIES]]].
         </p>
@@ -1012,8 +1014,7 @@ publishes an European Union ETSI Trust Services list [[ETSI-TRUST-LISTS]].
     "url": "https://ec.europa.example/",
     "recognizedIn": {
       "id": "https://ec.europa.example/tsl/lotl.xml",
-      "type": "EtsiTrustServiceList",
-      "name": "Utopian Commission List of the Lists"
+      "type": "ExternalEntityList"
     }
   }],
   "proof": {


### PR DESCRIPTION
This PR addresses Issue #71 by adding support for arbitrary entity registry lists.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-recognized-entities/pull/119.html" title="Last updated on Aug 26, 2026, 1:43 AM UTC (7747d5f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-recognized-entities/119/9e2ec97...7747d5f.html" title="Last updated on Aug 26, 2026, 1:43 AM UTC (7747d5f)">Diff</a>